### PR TITLE
Adjust setup of pre-commit hooks and formatting

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,20 @@
+name: pre-commit
+
+"on":
+  pull_request:
+  push:
+    branches:
+    - main
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - uses: pre-commit/action@v3.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ results/
 resources/
 networks/
 *.nc
+node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,4 +42,4 @@ repos:
   rev: v1.37.1
   hooks:
   - id: yamllint
-    exclude: ^tools/|^pypsa-earth/|^configs/config\.yaml$|^\.pre-commit-config\.yaml$
+    exclude: ^tools/|^pypsa-earth/|^configs/config\.yaml$|^\.pre-commit-config\.yaml$|^\.github/workflows/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,16 +4,17 @@ repos:
   hooks:
   - id: check-merge-conflict
   - id: end-of-file-fixer
+    exclude: ^tools/|^pypsa-earth/
   - id: mixed-line-ending
+    exclude: ^tools/|^pypsa-earth/
   - id: trailing-whitespace
+    exclude: ^tools/|^pypsa-earth/
 
 - repo: https://github.com/PyCQA/isort
   rev: 7.0.0
   hooks:
   - id: isort
-    args:
-    - --profile=black
-    - --filter-files
+    args: [--profile=black, --filter-files]
 
 - repo: https://github.com/psf/black-pre-commit-mirror
   rev: 25.12.0
@@ -25,26 +26,20 @@ repos:
   rev: v2.4.1
   hooks:
   - id: codespell
+    exclude: ^tools/|^pypsa-earth/
     args:
     - --ignore-regex=\b[A-Z]+\b
-    types_or:
-    - python
-    - markdown
+    types_or: [python, markdown]
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
   rev: v2.15.0
   hooks:
   - id: pretty-format-yaml
-    args:
-    - --autofix
-    - --indent
-    - "2"
-    - --preserve-quotes
+    args: [--autofix, --indent, "2", --preserve-quotes]
+    exclude: ^tools/|^pypsa-earth/|^configs/config\.yaml$
 
 - repo: https://github.com/adrienverge/yamllint.git
   rev: v1.37.1
   hooks:
   - id: yamllint
-    exclude: ^\.pre-commit-config\.yaml$
-    args:
-    - --format=parsable
+    exclude: ^tools/|^pypsa-earth/|^configs/config\.yaml$|^\.pre-commit-config\.yaml$

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+extends: default
+
+rules:
+  line-length: disable
+  document-start: disable


### PR DESCRIPTION
This PR updates pre-commit hooks for:
  - formatting (black)
  - linting (yamllint, codespell)
  - basic checks (merge conflicts, trailing whitespace, etc.)
  - enforces the same checks in CI for all pushes and pull requests

## How to use

Install pre-commit locally:

```bash
pip install pre-commit
pre-commit install
```

Run on all files:

`pre-commit run --all-files`