### PR TITLE
Country-specific cost data

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -403,14 +403,14 @@ renewable:
 # Costs Configuration
 costs:
   year: 2030 # cost file selection, i.e. costs_2030.csv in this case; reference year for costs is always 2020
-  technology_data_version: v0.13.2
+  technology_data_version: v0.14.0
   discountrate: [0.071] #, 0.086, 0.111]
-  country_specific_data: "" # (optional) Reference to the desired technology-data directory for techno-economic input data; Only "" and "US" supported, for other values check the technology-data output directory
+  country_specific_data: "US" # (optional) Reference to the desired technology-data directory for techno-economic input data; Only "" and "US" supported, for other values check the technology-data output directory
   # Only needed if "US" is selected as `country_specific_data`, otherwise ignore
   cost_scenario: "moderate" # only used if `country_specific_data: "US"`; can be "moderate", "advanced" or "conservative"
   financial_case: "market" # only used if `country_specific_data: "US"`; can be "market" or "r&d"
   # Management of output currencies and exchange rates
-  output_currency: "EUR" # full list of supported currencies at https://github.com/alexprengere/currencyconverter/blob/master/currency_converter/eurofxref.csv
+  output_currency: "AUD" # full list of supported currencies at https://github.com/alexprengere/currencyconverter/blob/master/currency_converter/eurofxref.csv
   default_exchange_rate: 0.7532 # previously USD2013_to_EUR2013; should be sufficient as current data from 'technology-data` are either in EUR or USD; [EUR/USD] ECB: https://www.ecb.europa.eu/stats/exchange/eurofxref/html/eurofxref-graph-usd.en.html
   future_exchange_rate_strategy: "reference" # reference uses the exchange rate from `reference_year` for all conversions, ensuring all costs are expressed in the same currency and year; "latest" uses the yearly average of the latest available exchange rates for the selected `output_currency`; "custom" allows to specify a `custom_future_exchange_rate` below
   custom_future_exchange_rate: None # if `future_exchange_rate_strategy: "custom"`, please insert here the desired output_currency-to-EUR exchange rate

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -52,7 +52,7 @@ scenario:
   planning_horizons: # investment years for myopic and perfect; or costs year for overnight
   - 2030
   sopts:
-  - "144h"
+  - "3h"
   demand:
   - "AB"
 
@@ -179,15 +179,15 @@ load_options:
 co2_budget:
   enable: true
   override_co2opt: true
-  co2base_value: co2limit # choose from: [co2limit, co2base, absolute, {float}]
+  co2base_value: co2base # choose from: [co2limit, co2base, absolute, {float}]
   year:
-    2030: 1.00
+    2030: 0.78 # to match co2limit (~ co2base * 0.78)
 
 electricity:
-  base_voltage: 380.
+  base_voltage: 330.
   voltages: [132., 220., 275., 330., 500.]
-  co2limit: 250.7e6 # t CO2eq
-  co2base: 321.8e6 # t CO2eq
+  co2limit: 250.7e+6 # t CO2eq (expected in 2030 considering a 71% contribution from mining, manufacturing, electricity, gas, water & waste
+  co2base: 321.8e+6 # t CO2eq (2023 - includes mining, manufacturing, electricity, gas, water & waste)
   agg_p_nom_limits: # enables to set country-wise maximum and minimum generation capacities for generators (e.g. renewables, nuclear, and geothermal)
     file: data/agg_p_nom_minmax.csv # path to csv file containing country-wise generation capacity limits
     include_existing: false # false: only new built capacities are constrained; true: existing capacities are accounted in the constraints
@@ -813,7 +813,7 @@ solving:
 
   solver:
     name: highs
-    options: highs-default
+    options: highs-hipo
 
   solver_options:
     highs-default:


### PR DESCRIPTION
This PR:
- updates cost-related parameters to use AUD as the reference currency and US-specific cost data
- revises config parameters for CO2 limits application
- restores base voltage level to 330 kV that was mistakenly overriden by a previously merged PR
- sets sector coupling resolution to 3h