### PR TITLE
Add configurable custom industry demand allocation modes

### DIFF
--- a/configs/config_2030.yaml
+++ b/configs/config_2030.yaml
@@ -42,6 +42,8 @@ custom_industry:
   e_share:
     ammonia: 0.0
     methanol: 0.0
+  demand_allocation:
+    mode: brownfield_optimised_growth # choose from ["proportional_existing_capacity" or "brownfield_optimised_growth" or "greenfield_optimised_growth"]
 
 custom_rules: # Default empty [] or link to custom rule file e.g. ["my_folder/my_rules.smk"] that add rules to Snakefile
 - "../scripts/custom_rules.smk"

--- a/scripts/custom_add_explicit_industry.py
+++ b/scripts/custom_add_explicit_industry.py
@@ -351,14 +351,310 @@ def add_e_methanol(n, industrial_demand, costs, config, nhours):
     logger.info("Added e-methanol demand.")
 
 
-def add_custom_explicit_industry(n, industrial_demand, costs, config, nhours):
+def _get_base_electricity_nodes(n):
+    """
+    Return base electricity nodes where greenfield custom industry can be added.
+    """
+    if "carrier" in n.buses.columns:
+        nodes = n.buses.index[n.buses.carrier == "AC"]
+
+        if len(nodes) > 0:
+            return pd.Index(nodes)
+
+    return pd.Index(
+        [
+            bus
+            for bus in n.buses.index
+            if not any(
+                suffix in bus
+                for suffix in [
+                    " gas",
+                    " H2",
+                    " co2",
+                    "ammonia",
+                    "methanol",
+                    "battery",
+                    "heat",
+                ]
+            )
+        ]
+    )
+
+
+def _required_custom_industry_buses_exist(n, node):
+    """
+    Check whether all required input buses exist for custom industry technologies.
+    """
+    required_buses = [
+        node,
+        node + " gas",
+        node + " grey H2",
+        node + " grid H2",
+        node + " co2 stored",
+    ]
+
+    return all(bus in n.buses.index for bus in required_buses)
+
+
+def _expand_industrial_demand_for_greenfield(n, industrial_demand):
+    """
+    Add zero-demand rows for greenfield candidate nodes.
+
+    This creates candidate production links at nodes without existing baseline demand.
+    """
+    candidate_nodes = _get_base_electricity_nodes(n)
+    candidate_nodes = pd.Index(
+        [
+            node
+            for node in candidate_nodes
+            if _required_custom_industry_buses_exist(n, node)
+        ]
+    )
+
+    if candidate_nodes.empty:
+        raise ValueError(
+            "No feasible greenfield custom industry candidate nodes were found."
+        )
+
+    industrial_demand = industrial_demand.copy()
+
+    required_columns = [
+        "grey_ammonia",
+        "e_ammonia",
+        "grey_methanol",
+        "e_methanol",
+    ]
+
+    for col in required_columns:
+        if col not in industrial_demand.columns:
+            industrial_demand[col] = 0.0
+
+    missing_nodes = candidate_nodes.difference(industrial_demand.index)
+
+    if len(missing_nodes) > 0:
+        extra = pd.DataFrame(
+            0.0,
+            index=missing_nodes,
+            columns=required_columns,
+        )
+        industrial_demand = pd.concat([industrial_demand, extra], axis=0)
+
+    return industrial_demand
+
+
+def _get_brownfield_reference_carrier(growth_carrier):
+    """
+    Return the baseline carrier that defines brownfield eligibility.
+
+    Baseline is always grey, so e-fuel growth is allowed at nodes where the
+    corresponding grey product already exists.
+    """
+    mapping = {
+        "grey_ammonia": "grey_ammonia",
+        "e_ammonia": "grey_ammonia",
+        "grey_methanol": "grey_methanol",
+        "e_methanol": "grey_methanol",
+    }
+
+    if growth_carrier not in mapping:
+        raise ValueError(
+            f"Unsupported custom industry growth carrier: {growth_carrier}"
+        )
+
+    return mapping[growth_carrier]
+
+
+def _get_growth_candidate_nodes(n, industrial_demand, mode, growth_carrier=None):
+    """
+    Return candidate nodes for optimised custom industry growth.
+    """
+    if mode == "brownfield_optimised_growth":
+        if growth_carrier is None:
+            raise ValueError("growth_carrier must be provided for brownfield mode.")
+
+        reference_carrier = _get_brownfield_reference_carrier(growth_carrier)
+
+        if reference_carrier not in industrial_demand.columns:
+            raise ValueError(
+                f"Reference carrier '{reference_carrier}' not found in industrial_demand."
+            )
+
+        return pd.Index(
+            industrial_demand.index[
+                industrial_demand[reference_carrier].fillna(0.0) > 0.0
+            ]
+        )
+
+    if mode == "greenfield_optimised_growth":
+        return pd.Index(
+            [
+                node
+                for node in _get_base_electricity_nodes(n)
+                if _required_custom_industry_buses_exist(n, node)
+            ]
+        )
+
+    raise ValueError(f"Unsupported custom industry growth mode: {mode}")
+
+
+def _get_product_bus_suffix_and_carrier(growth_carrier):
+    """
+    Map growth target carrier names to product bus suffixes and network carriers.
+    """
+    mapping = {
+        "grey_ammonia": (" grey-ammonia", "grey-ammonia"),
+        "e_ammonia": (" e-ammonia", "e-ammonia"),
+        "grey_methanol": (" grey-methanol", "grey-methanol"),
+        "e_methanol": (" e-methanol", "e-methanol"),
+    }
+
+    if growth_carrier not in mapping:
+        raise ValueError(
+            f"Unsupported custom industry growth carrier: {growth_carrier}"
+        )
+
+    return mapping[growth_carrier]
+
+
+def add_custom_industry_growth_market(
+    n,
+    industrial_demand,
+    growth_targets,
+    mode,
+    nhours,
+):
+    """
+    Add aggregate growth demand through national market buses.
+
+    Candidate product buses can feed the market bus via zero-cost extendable links.
+    The optimiser then chooses the cheapest production locations.
+    """
+
+    active_growth = growth_targets[growth_targets["growth_mwh"] > 0].copy()
+
+    if active_growth.empty:
+        logger.info("No positive custom industry growth targets to add.")
+        return
+
+    for _, row in active_growth.iterrows():
+        growth_carrier = row["carrier"]
+        growth_mwh = row["growth_mwh"]
+
+        candidate_nodes = _get_growth_candidate_nodes(
+            n,
+            industrial_demand,
+            mode,
+            growth_carrier=growth_carrier,
+        )
+
+        if candidate_nodes.empty:
+            raise ValueError(
+                f"No candidate nodes found for growth carrier '{growth_carrier}' "
+                f"and mode '{mode}'."
+            )
+
+        product_suffix, product_carrier = _get_product_bus_suffix_and_carrier(
+            growth_carrier
+        )
+
+        market_bus = f"custom industry {product_carrier} growth market"
+        growth_load = f"custom industry {product_carrier} growth demand"
+
+        if market_bus not in n.buses.index:
+            n.add(
+                "Bus",
+                market_bus,
+                carrier=product_carrier,
+                location="AU",
+            )
+
+        n.add(
+            "Load",
+            growth_load,
+            bus=market_bus,
+            carrier=product_carrier,
+            p_set=growth_mwh / nhours,
+        )
+
+        product_buses = pd.Series(
+            candidate_nodes + product_suffix,
+            index=candidate_nodes,
+        )
+
+        product_buses = product_buses[product_buses.isin(n.buses.index)]
+
+        if product_buses.empty:
+            raise ValueError(
+                f"No product buses found for growth carrier '{growth_carrier}' "
+                f"and mode '{mode}'."
+            )
+
+        link_names = product_buses.index + f" {product_carrier} growth export"
+
+        n.madd(
+            "Link",
+            link_names,
+            bus0=product_buses.values,
+            bus1=market_bus,
+            carrier=f"{product_carrier} growth export",
+            p_nom_extendable=True,
+            efficiency=1.0,
+            capital_cost=0.0,
+            marginal_cost=0.0,
+        )
+
+        logger.warning(
+            f"Added custom industry growth market for {product_carrier}: "
+            f"{growth_mwh:.2f} MWh/a across {len(product_buses)} candidate nodes "
+            f"using mode={mode}."
+        )
+
+
+def add_custom_explicit_industry(
+    n,
+    industrial_demand,
+    costs,
+    config,
+    nhours,
+    growth_targets=None,
+):
     """
     Add all custom explicit industry sectors currently implemented.
     """
+    mode = (
+        config.get("custom_industry", {})
+        .get("demand_allocation", {})
+        .get("mode", "proportional_existing_capacity")
+    )
+
+    if mode == "greenfield_optimised_growth":
+        industrial_demand = _expand_industrial_demand_for_greenfield(
+            n,
+            industrial_demand,
+        )
+
     add_grey_ammonia(n, industrial_demand, costs, config, nhours)
     add_e_ammonia(n, industrial_demand, costs, config, nhours)
     add_grey_methanol(n, industrial_demand, costs, config, nhours)
     add_e_methanol(n, industrial_demand, costs, config, nhours)
+
+    if mode == "proportional_existing_capacity":
+        return n
+
+    if growth_targets is None or growth_targets.empty:
+        raise ValueError(
+            "Optimised custom industry growth mode selected, but no "
+            "growth targets were provided."
+        )
+
+    add_custom_industry_growth_market(
+        n=n,
+        industrial_demand=industrial_demand,
+        growth_targets=growth_targets,
+        mode=mode,
+        nhours=nhours,
+    )
+
     return n
 
 
@@ -372,6 +668,19 @@ if __name__ == "__main__":
         index_col=0,
     )
     industrial_demand = industrial_demand.drop(columns=["country"], errors="ignore")
+
+    growth_targets = pd.DataFrame(
+        columns=[
+            "product",
+            "carrier",
+            "growth_tpa",
+            "growth_mwh",
+            "conversion_factor_mwh_per_t",
+        ]
+    )
+
+    if hasattr(snakemake.input, "growth_targets"):
+        growth_targets = pd.read_csv(snakemake.input.growth_targets)
 
     nhours = n.snapshot_weightings.generators.sum()
     Nyears = nhours / 8760
@@ -387,7 +696,14 @@ if __name__ == "__main__":
         snakemake.params.costs["custom_future_exchange_rate"],
     )
 
-    add_custom_explicit_industry(n, industrial_demand, costs, config, nhours)
+    add_custom_explicit_industry(
+        n,
+        industrial_demand,
+        costs,
+        config,
+        nhours,
+        growth_targets,
+    )
 
     sanitize_carriers(n, snakemake.config)
     sanitize_locations(n)

--- a/scripts/custom_build_industry_demand.py
+++ b/scripts/custom_build_industry_demand.py
@@ -15,6 +15,32 @@ NH3_MWH_PER_TON = 5.17
 MEOH_MWH_PER_TON = 5.54
 
 
+VALID_DEMAND_ALLOCATION_MODES = {
+    "proportional_existing_capacity",
+    "brownfield_optimised_growth",
+    "greenfield_optimised_growth",
+}
+
+
+def get_demand_allocation_mode(config: dict) -> str:
+    """
+    Read custom industry demand allocation mode from config.
+    """
+    mode = (
+        config.get("custom_industry", {})
+        .get("demand_allocation", {})
+        .get("mode", "proportional_existing_capacity")
+    )
+
+    if mode not in VALID_DEMAND_ALLOCATION_MODES:
+        raise ValueError(
+            f"Invalid custom industry demand allocation mode '{mode}'. "
+            f"Expected one of {sorted(VALID_DEMAND_ALLOCATION_MODES)}."
+        )
+
+    return mode
+
+
 def load_gem_data(path: str) -> pd.DataFrame:
     """
     Load GEM plant-level data and keep only Australian ammonia/methanol plants.
@@ -83,44 +109,98 @@ def merge_data(gem_df: pd.DataFrame, cap_df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def allocate_and_split(df: pd.DataFrame, targets: dict, e_shares: dict) -> pd.DataFrame:
+def allocate_and_split(
+    df: pd.DataFrame,
+    targets: dict,
+    e_shares: dict,
+    mode: str,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
     """
-    Allocate 2030 total production targets proportionally to historical capacity,
-    then split them into grey and e- fractions according to config shares.
+    Allocate custom industry demand.
+
+    The CSV production capacity is always treated as the existing baseline.
+    The baseline is always grey.
+
+    The e_share is applied only to the demand growth, not to the baseline.
+
+    Modes:
+    - proportional_existing_capacity:
+        Growth is allocated proportionally to existing plant capacity.
+    - brownfield_optimised_growth:
+        Growth is not allocated here. It is returned as an aggregate target
+        to be optimised later on existing industry nodes.
+    - greenfield_optimised_growth:
+        Growth is not allocated here. It is returned as an aggregate target
+        to be optimised later on candidate nodes.
     """
     df = df.copy()
     df["industry"] = df["Primary products"]
-    df["total_2030_tpa"] = 0.0
+
+    growth_records = []
 
     for product, target in targets.items():
         mask = df["industry"] == product
-        total_capacity = df.loc[mask, "Production capacity (tpa)"].sum()
 
-        if total_capacity == 0:
-            raise ValueError(f"No production capacity found for product '{product}'.")
+        baseline = df.loc[mask, "Production capacity (tpa)"].fillna(0.0)
+        baseline_total = baseline.sum()
 
-        shares = df.loc[mask, "Production capacity (tpa)"] / total_capacity
-        df.loc[mask, "total_2030_tpa"] = shares * target
+        if baseline_total == 0:
+            raise ValueError(f"No baseline capacity found for product '{product}'.")
 
-        logger.info(
-            f"{product}: historical total = {total_capacity:.2f} tpa, "
-            f"2030 target = {target:.2f} tpa"
-        )
+        growth = target - baseline_total
 
-    for product in targets.keys():
+        if growth < 0:
+            raise ValueError(
+                f"Target for '{product}' ({target:.2f} tpa) is lower than "
+                f"baseline CSV capacity ({baseline_total:.2f} tpa). "
+                "Downscaling is not implemented for custom industry demand."
+            )
+
         e_share = e_shares.get(product, 0.0)
 
         if not 0 <= e_share <= 1:
             raise ValueError(f"e_share for '{product}' must be between 0 and 1.")
 
-        mask = df["industry"] == product
+        df.loc[mask, f"e_{product}_tpa"] = 0.0
+        df.loc[mask, f"grey_{product}_tpa"] = baseline
 
-        df.loc[mask, f"e_{product}_tpa"] = df.loc[mask, "total_2030_tpa"] * e_share
-        df.loc[mask, f"grey_{product}_tpa"] = df.loc[mask, "total_2030_tpa"] * (
-            1 - e_share
+        if mode == "proportional_existing_capacity":
+            shares = baseline / baseline_total
+
+            allocated_e_growth = shares * growth * e_share
+            allocated_grey_growth = shares * growth * (1 - e_share)
+
+            df.loc[mask, f"e_{product}_tpa"] += allocated_e_growth
+            df.loc[mask, f"grey_{product}_tpa"] += allocated_grey_growth
+
+            growth_for_model = 0.0
+        else:
+            growth_for_model = growth
+
+        growth_records.extend(
+            [
+                {
+                    "product": product,
+                    "carrier": f"e_{product}",
+                    "growth_tpa": growth_for_model * e_share,
+                },
+                {
+                    "product": product,
+                    "carrier": f"grey_{product}",
+                    "growth_tpa": growth_for_model * (1 - e_share),
+                },
+            ]
         )
 
-    return df
+        logger.info(
+            f"{product}: baseline = {baseline_total:.2f} tpa, "
+            f"target = {target:.2f} tpa, growth = {growth:.2f} tpa, "
+            f"e_share_on_growth = {e_share:.2f}, mode = {mode}"
+        )
+
+    growth_targets = pd.DataFrame(growth_records)
+
+    return df, growth_targets
 
 
 def convert_to_mwh(df: pd.DataFrame) -> pd.DataFrame:
@@ -136,6 +216,42 @@ def convert_to_mwh(df: pd.DataFrame) -> pd.DataFrame:
     df["grey_methanol"] = df.get("grey_methanol_tpa", 0.0) * MEOH_MWH_PER_TON
 
     return df
+
+
+def convert_growth_targets_to_mwh(growth_targets: pd.DataFrame) -> pd.DataFrame:
+    """
+    Convert aggregate growth targets from tpa to MWh/a.
+    """
+    growth_targets = growth_targets.copy()
+
+    factors = {
+        "ammonia": NH3_MWH_PER_TON,
+        "methanol": MEOH_MWH_PER_TON,
+    }
+
+    growth_targets["conversion_factor_mwh_per_t"] = growth_targets["product"].map(
+        factors
+    )
+
+    if growth_targets["conversion_factor_mwh_per_t"].isna().any():
+        missing = growth_targets.loc[
+            growth_targets["conversion_factor_mwh_per_t"].isna(), "product"
+        ].unique()
+        raise ValueError(f"Missing conversion factors for products: {missing}")
+
+    growth_targets["growth_mwh"] = (
+        growth_targets["growth_tpa"] * growth_targets["conversion_factor_mwh_per_t"]
+    )
+
+    return growth_targets[
+        [
+            "product",
+            "carrier",
+            "growth_tpa",
+            "growth_mwh",
+            "conversion_factor_mwh_per_t",
+        ]
+    ]
 
 
 def prepare_mapping(df: pd.DataFrame) -> pd.DataFrame:
@@ -290,13 +406,31 @@ if __name__ == "__main__":
     cap_df = load_capacity_data(capacity_path)
 
     df = merge_data(gem_df, cap_df)
-    df = allocate_and_split(df, targets, e_shares)
+
+    mode = get_demand_allocation_mode(config)
+
+    df, growth_targets = allocate_and_split(
+        df,
+        targets,
+        e_shares,
+        mode,
+    )
+
     df = convert_to_mwh(df)
+    growth_targets = convert_growth_targets_to_mwh(growth_targets)
+
     df = prepare_mapping(df)
 
     if hasattr(snakemake.output, "plants"):
         df.to_csv(snakemake.output.plants, index=False)
         logger.info("Saved merged plant-level custom industry dataset.")
+
+    if hasattr(snakemake.output, "growth_targets"):
+        logger.warning(
+            f"Writing growth_targets to {snakemake.output.growth_targets} | "
+            f"mode={mode} | targets={targets} | e_share={e_shares}"
+        )
+        growth_targets.to_csv(snakemake.output.growth_targets, index=False)
 
     df_expanded = explode_by_carrier(df)
 

--- a/scripts/custom_rules.smk
+++ b/scripts/custom_rules.smk
@@ -28,6 +28,9 @@ if config.get("custom_industry", {}).get("enable", False):
             countries=config["countries"],
             gadm_layer_id=config["build_shape_options"]["gadm_layer_id"],
             alternative_clustering=config["cluster_options"]["alternative_clustering"],
+            demand_allocation_mode=lambda wildcards: config["custom_industry"]["demand_allocation"]["mode"],
+            targets_tpa=lambda wildcards: str(config["custom_industry"]["targets_tpa"]),
+            e_share=lambda wildcards: str(config["custom_industry"]["e_share"]),
         input:
             gem_data="../data/industry/Plant-level-data-Global-Chemicals-Inventory-November-2025-V1.xlsx",
             capacity_data="../data/industry/ammonia_methanol_production_per_plant_au.xlsx",
@@ -42,6 +45,11 @@ if config.get("custom_industry", {}).get("enable", False):
                 "resources/"
                 + SECDIR
                 + "demand/custom_industry_plants_elec_s{simpl}_{clusters}_{planning_horizons}_{demand}.csv"
+            ),
+            growth_targets=(
+                "resources/"
+                + SECDIR
+                + "demand/custom_industry_growth_targets_elec_s{simpl}_{clusters}_{planning_horizons}_{demand}.csv"
             ),
         log:
             "logs/"
@@ -75,6 +83,11 @@ if config.get("custom_industry", {}).get("enable", False):
                 + "prenetworks/elec_s{simpl}_{clusters}_ec_l{ll}_{opts}_{sopts}_{planning_horizons}_{discountrate}_{demand}.nc"
             ),
             costs="resources/" + RDIR + "costs_{planning_horizons}.csv",
+            growth_targets=(
+                "resources/"
+                + SECDIR
+                + "demand/custom_industry_growth_targets_elec_s{simpl}_{clusters}_{planning_horizons}_{demand}.csv"
+            ),
         output:
             modified_network=(
                 "results/"


### PR DESCRIPTION
## Add configurable custom industry demand allocation modes

This PR introduces a configurable framework to control how additional
custom industry demand (e.g. ammonia and methanol) is allocated across
the network.

Custom industry demand is now decomposed into:

-   **Baseline demand**: derived from plant-level CSV data (always treated as grey production)
-   **Growth demand**: the difference between target demand and baseline, handled according to the selected allocation mode

The share of e-fuels (`e_share`) is applied **only to the growth
component**, while baseline demand remains unchanged.

## New configuration options

``` yaml
custom_industry:
    mode: brownfield_optimised_growth # choose from ["proportional_existing_capacity" or  brownfield_optimised_growth" or "greenfield_optimised_growth"]
```

## Implemented allocation modes

### 1. Proportional allocation

All demand is distributed proportionally to existing plant capacities.

### 2. Brownfield optimised growth

Growth is optimised only across existing nodes.

### 3. Greenfield optimised growth

Growth is optimised across all feasible nodes.

## Current Limitations

-   No transport costs
-   No transport constraints
-   Possible spatial concentration