### PR TITLE
Add import shock insurance analysis using precomputed Zenodo scenarios

### DIFF
--- a/streamlit/app.py
+++ b/streamlit/app.py
@@ -142,9 +142,9 @@ T_PER_GJ_DIESEL = 42.8  # or MT per PJ
 DEFAULT_E_SHARE = 0.50
 DEFAULT_E_SHARE_PRODUCTION = 0.30
 
-INSURANCE_SCENARIO_RECORD_ID = "20559877"
+INSURANCE_SCENARIO_RECORD_ID = "20594872"
 INSURANCE_SCENARIO_URL = f"https://zenodo.org/records/{INSURANCE_SCENARIO_RECORD_ID}"
-GREEN_LOCAL_PRODUCTION_SHARES = [20, 40, 60, 80, 100]
+GREEN_LOCAL_PRODUCTION_SHARES = [0, 20, 40, 60, 80, 100]
 
 # ----- diesel / methanol demand
 # source: Department of Climate Change, Energy, the Environment and Water, Australian Energy Statistics, Table F, August 2025
@@ -789,7 +789,7 @@ with t_welcome:
     **Use the sidebar to load your network and set project targets. Then, navigate through the tabs to manage different aspects of your project (economic and demand parameters).**
 
     By default it is assumed that {DEFAULT_E_SHARE * 100}% of the diesel demand can be reduced by electrification.
-    Additionally it is assumed that {DEFAULT_E_SHARE_PRODUCTION * 100}% of the remaining diesel and ammonia demand shall be covered by local green production.
+    Additionally it is assumed that {DEFAULT_E_SHARE_PRODUCTION * 100}% of the remaining diesel and ammonia demand shall be covered by local e-fuel production.
     To review and/or adjust the required methanol and/or ammonia demand settings pull down the relevant pull-down box.
     The calculated e-methanol and e-ammonia production values are automatically transferred to the “Demand Parameters” tab, where they can still be manually adjusted before being applied to the network.
     """)
@@ -1797,11 +1797,12 @@ with t_results:
                 """)
             st.markdown(f"""
                 Scenarios included:
-                - 20% green local production
-                - 40% green local production
-                - 60% green local production
-                - 80% green local production
-                - 100% green local production
+                - 0% local e-fuel production
+                - 20% local e-fuel production
+                - 40% local e-fuel production
+                - 60% local e-fuel production
+                - 80% local e-fuel production
+                - 100% local e-fuel production
                 """)
             if st.session_state.n is None:
                 st.info(
@@ -1833,27 +1834,16 @@ with t_results:
                 st.stop()
 
             scenario_display_labels = {
-                key: f"{key.replace('greenlocprod', '')}% local green production"
-                for key in insurance_networks
+                key: f"{key.replace('greenlocprod', '')}%" for key in insurance_networks
             }
 
-            baseline_label = st.selectbox(
-                "Select baseline scenario",
-                list(insurance_networks.keys()),
-                index=0,
-                format_func=lambda key: scenario_display_labels[key],
+            baseline_label = "greenlocprod0"
+
+            st.info(
+                "All scenarios are compared against the 0% local e-fuel production reference case."
             )
 
-            diesel_shocks = st.multiselect(
-                "Assumed increase in imported fuel prices (AUD/t diesel-equivalent)",
-                [0, 150, 300, 450, 600],
-                default=[0, 150, 300, 450, 600],
-            )
-
-            st.caption(
-                "These are post-processing sensitivity assumptions representing potential increases in imported fuel prices. "
-                "They are not optimized in the model."
-            )
+            diesel_shocks_l = [0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
 
             ammonia_shock = st.number_input(
                 "Assumed ammonia import price shock (AUD/t NH3)",
@@ -1863,7 +1853,7 @@ with t_results:
             )
 
             st.caption(
-                "This shock is applied to additional e-ammonia production relative to the selected baseline."
+                "This shock is applied to additional e-ammonia production relative to the 0% local e-fuel production reference case."
             )
 
             baseline_network = insurance_networks[baseline_label]
@@ -1914,7 +1904,8 @@ with t_results:
                     }
                 )
 
-                for diesel_shock in diesel_shocks:
+                for diesel_shock_l in diesel_shocks_l:
+                    diesel_shock = diesel_shock_l * 1000 / KG_PER_LITER_DIESEL
                     value_of_displaced_import_exposure = (
                         additional_diesel_equivalent * 1e6 * diesel_shock
                         + additional_nh3 * 1e6 * ammonia_shock
@@ -1927,7 +1918,7 @@ with t_results:
                     rows.append(
                         {
                             "Scenario": scenario_display_labels[scenario_label],
-                            "Assumed diesel-equivalent import price increase (AUD/t)": diesel_shock,
+                            "Assumed diesel import price increase (AUD/liter)": diesel_shock_l,
                             "Ammonia import price increase (AUD/t NH3)": ammonia_shock,
                             "System cost (MAUD/year)": scenario_cost,
                             "Additional system cost relative to baseline (MAUD/year)": additional_system_cost,
@@ -1939,64 +1930,47 @@ with t_results:
             insurance_df = pd.DataFrame(rows)
             scenario_detail_df = pd.DataFrame(scenario_detail_rows)
 
-            st.info("""
-                The chart shows the net insurance benefit for each local green
-                production scenario and each assumed import price shock.
-
-                For each scenario and shock level:
-
-                Net insurance benefit =
-                Value of displaced import exposure
-                - Additional system cost relative to the selected baseline.
-
-                Value of displaced import exposure =
-                Additional diesel-equivalent fuel displacement × assumed fuel price shock
-                + additional e-ammonia production × assumed ammonia price shock.
-
-                Additional diesel-equivalent fuel displacement is calculated from
-                additional e-methanol production using the energy-content ratio:
-
-                Additional diesel-equivalent fuel displacement =
-                Additional e-methanol production
-                × MWh per tonne e-methanol
-                / MWh per tonne diesel.
-
-                The analysis does not model imports explicitly. Instead, it estimates
-                the economic value of reducing exposure to imported liquid fuels and
-                ammonia under assumed import price increases.
-                """)
-
-            st.dataframe(
-                insurance_df.round(2),
-                hide_index=True,
-                width="stretch",
-            )
-
-            with st.expander("Show scenario demand details", expanded=False):
-                st.dataframe(
-                    scenario_detail_df.round(2),
-                    hide_index=True,
-                    width="stretch",
-                )
-
             chart = (
                 alt.Chart(insurance_df)
-                .mark_line(point=True)
+                .mark_line(point=True, strokeWidth=3, size=80)
                 .encode(
                     x=alt.X(
-                        "Assumed diesel-equivalent import price increase (AUD/t):Q",
-                        title="Assumed diesel-equivalent import price increase (AUD/t)",
+                        "Assumed diesel import price increase (AUD/liter):Q",
+                        title="Assumed diesel import price increase (AUD/liter)",
+                        axis=alt.Axis(
+                            labelFontSize=18,
+                            titleFontSize=20,
+                        ),
                     ),
                     y=alt.Y(
                         "Net insurance benefit (MAUD/year):Q",
                         title="Net insurance benefit (MAUD/year)",
+                        axis=alt.Axis(
+                            labelFontSize=18,
+                            titleFontSize=20,
+                        ),
                     ),
-                    color=alt.Color("Scenario:N", title="Scenario"),
+                    color=alt.Color(
+                        "Scenario:N",
+                        title="Local e-fuel production share",
+                        scale=alt.Scale(
+                            domain=["0%", "20%", "40%", "60%", "80%", "100%"],
+                        ),
+                        legend=alt.Legend(
+                            orient="bottom",
+                            direction="horizontal",
+                            columns=6,
+                            labelFontSize=18,
+                            titleFontSize=20,
+                            labelLimit=0,
+                            titleLimit=0,
+                        ),
+                    ),
                     tooltip=[
                         "Scenario:N",
                         alt.Tooltip(
-                            "Assumed diesel-equivalent import price increase (AUD/t):Q",
-                            format=",.0f",
+                            "Assumed diesel import price increase (AUD/liter):Q",
+                            format=".1f",
                         ),
                         alt.Tooltip(
                             "Ammonia import price increase (AUD/t NH3):Q",
@@ -2020,10 +1994,33 @@ with t_results:
                         ),
                     ],
                 )
-                .properties(height=500)
+                .properties(height=750)
             )
 
             st.altair_chart(chart, width="stretch")
+
+            st.info("""
+                **How to read this chart**
+
+                - Each line represents a different level of **local e-fuel production** (0-100%). The same share is applied to both e-methanol production for diesel replacement and e-ammonia production for fertilizer demand.
+                - The **x-axis** shows hypothetical increases in imported diesel prices (AUD/liter).
+                - The **y-axis** shows the **net insurance benefit** (MAUD/year).
+
+                Negative values mean the additional cost of domestic e-fuel production is larger than the value of reduced import exposure.
+
+                Positive values mean the value of reduced exposure to import price shocks exceeds the additional system cost.
+
+                The point where a line crosses **0 MAUD/year** indicates the diesel import price increase at which that local production level becomes economically justified from an insurance perspective.
+
+                This analysis does not explicitly model imports. It estimates the value of reducing exposure to future import price increases using precomputed PyPSA scenarios.
+                """)
+
+            with st.expander("Show scenario demand details", expanded=False):
+                st.dataframe(
+                    scenario_detail_df.round(2),
+                    hide_index=True,
+                    width="stretch",
+                )
 
             st.stop()
 

--- a/streamlit/app.py
+++ b/streamlit/app.py
@@ -2044,14 +2044,15 @@ with t_results:
 
             scenario_detail_df = scenario_detail_df.rename(
                 columns={
+                    "Scenario": "Local e-fuel production share",
                     "Additional system cost relative to baseline (MAUD/year)": (
-                        "Additional system cost (MAUD/year)"
+                        "Annual insurance cost (MAUD/year)"
                     ),
                     "Additional diesel-equivalent fuel displacement relative to baseline (Mtpa)": (
-                        "Additional diesel-equivalent fuel displacement (Mtpa)"
+                        "Reduced diesel import exposure (Mtpa diesel-eq.)"
                     ),
                     "Additional e-ammonia relative to baseline (Mtpa)": (
-                        "Additional e-ammonia production (Mtpa)"
+                        "Reduced ammonia import exposure (Mtpa NH3)"
                     ),
                 }
             )

--- a/streamlit/app.py
+++ b/streamlit/app.py
@@ -1618,6 +1618,7 @@ with t_optimization:
                             assign_all_duals=False,
                             solver_options=solver_options,
                             remote=remote,
+                            include_objective_constant=True,
                         )
 
                 except Exception as exc:
@@ -1708,10 +1709,6 @@ with t_results:
         if "scenario_metadata" in st.session_state:
             st.subheader("Scenario Overviews")
 
-            st.caption(
-                "Hydrogen and hydrogen-based derivative demands are reported in Mtpa."
-            )
-
             scenario_rows = []
 
             for k, v in st.session_state.scenario_metadata.items():
@@ -1751,770 +1748,784 @@ with t_results:
 
             scenario_df = pd.DataFrame(scenario_rows)
 
-            st.dataframe(
-                scenario_df,
-                hide_index=True,
-                width="stretch",
-            )
-
-        available_runs = list(st.session_state.solved_networks.keys())
-        label_map = st.session_state.scenario_labels
-
-        run_lookup = {label_map.get(run, run): run for run in available_runs}
-
-        selected_labels = st.multiselect(
-            "Select solved scenarios",
-            list(run_lookup.keys()),
-            default=list(run_lookup.keys()),
-            width="stretch",
-        )
-
-        selected_runs = [run_lookup[label] for label in selected_labels]
-
-        st.write("")
-        result_view = st.radio(
-            "Select result view",
-            [
-                "Commodity cost maps",
-                "Installed capacity",
-                "Dispatch",
-                "System costs",
-                # "Technical comparison",
-                "Economic comparison",
-            ],
-            horizontal=True,
-        )
-
-        if selected_runs:
-            selected_networks = {
-                label_map.get(run, run): st.session_state.solved_networks[run]
-                for run in selected_runs
-            }
-
-            st.subheader(result_view)
-
-            # INSTALLED CAPACITY
-
-            if result_view == "Installed capacity":
-                category = st.radio(
-                    "Select result category",
-                    get_available_result_categories(),
-                    horizontal=True,
+            if len(scenario_df) > 0:
+                st.caption(
+                    "Hydrogen and hydrogen-based derivative demands are reported in Mtpa."
                 )
 
-                if category == "Electricity":
-                    cap_df = compute_capacity_by_carrier(
-                        selected_networks,
-                        category,
-                    )
-                    y_label = "GW"
-                    result_title = "Electricity - Installed capacity"
-
-                elif category == "CO2 capture":
-                    cap_df = compute_annual_flow_by_carrier(
-                        selected_networks,
-                        category,
-                        MWH_PER_TONNE,
-                    )
-                    y_label = "Mtpa"
-                    result_title = "CO2 capture - Annual capture"
-
-                else:
-                    cap_df = compute_annual_flow_by_carrier(
-                        selected_networks,
-                        category,
-                        MWH_PER_TONNE,
-                    )
-                    y_label = "Mtpa"
-                    result_title = f"{category} - Annual production capacity"
-
-                st.subheader(result_title)
-
-                if cap_df.empty:
-                    st.warning(f"No result data found for {category}.")
-
-                else:
-                    chart_df = cap_df.pivot_table(
-                        index="scenario",
-                        columns="carrier",
-                        values="value",
-                        aggfunc="sum",
-                        fill_value=0.0,
-                    )
-
-                    plot_df = chart_df.reset_index().melt(
-                        id_vars="scenario",
-                        var_name="Technology",
-                        value_name="Value",
-                    )
-
-                    tech_totals = plot_df.groupby("Technology")["Value"].sum()
-
-                    shown_techs = [
-                        tech
-                        for tech in DISPATCH_COLORS
-                        if tech in tech_totals.index and tech_totals[tech] > 0
-                    ]
-
-                    chart = (
-                        alt.Chart(plot_df)
-                        .mark_bar()
-                        .encode(
-                            x=alt.X(
-                                "scenario:N",
-                                title="Scenario",
-                                axis=alt.Axis(labelAngle=0),
-                            ),
-                            y=alt.Y(
-                                "Value:Q",
-                                stack="zero",
-                                title=y_label,
-                            ),
-                            color=alt.Color(
-                                "Technology:N",
-                                title="Technology",
-                                scale=alt.Scale(
-                                    domain=shown_techs,
-                                    range=[DISPATCH_COLORS[t] for t in shown_techs],
-                                ),
-                            ),
-                            tooltip=[
-                                alt.Tooltip("scenario:N"),
-                                alt.Tooltip("Technology:N"),
-                                alt.Tooltip(
-                                    "Value:Q",
-                                    format=",.2f",
-                                ),
-                            ],
-                        )
-                        .properties(height=600)
-                    )
-
-                    st.altair_chart(chart, width="stretch")
-
-                    APP_DIR = Path(__file__).resolve().parent
-
-                    shape_path = (
-                        APP_DIR / "data" / "shapes" / "australia_states.geojson"
-                    )
-
-                    try:
-                        shapes = gpd.read_file(shape_path)
-
-                        map_unit = "GW" if category == "Electricity" else "Mtpa"
-
-                        for capacity_run in selected_runs:
-                            capacity_label = label_map.get(
-                                capacity_run,
-                                capacity_run,
-                            )
-
-                            st.markdown(f"### Scenario {capacity_label}")
-
-                            capacity_by_bus = compute_capacity_by_bus(
-                                st.session_state.solved_networks[capacity_run],
-                                category,
-                            )
-
-                            if capacity_by_bus.empty:
-                                st.warning(
-                                    f"No mapped capacity data found for scenario {capacity_label}."
-                                )
-                                continue
-
-                            n_map = st.session_state.solved_networks[capacity_run]
-
-                            map_network = None
-
-                            if category == "Electricity":
-                                map_network = n_map
-
-                            fig = plot_capacity_map_by_bus(
-                                capacity_by_bus,
-                                shapes,
-                                DISPATCH_COLORS,
-                                network=map_network,
-                                unit=map_unit,
-                            )
-
-                            st.pyplot(fig, width="content")
-
-                    except Exception as exc:
-                        st.error(f"Could not build capacity map: {exc}")
-
-                    table_df = (
-                        cap_df.drop(
-                            columns=["component"],
-                            errors="ignore",
-                        )
-                        .pivot_table(
-                            index=["carrier", "unit"],
-                            columns="scenario",
-                            values="value",
-                            aggfunc="sum",
-                            fill_value=0.0,
-                        )
-                        .reset_index()
-                        .rename(
-                            columns={
-                                "carrier": "Carrier",
-                                "unit": "Unit",
-                            }
-                        )
-                    )
-
-                    with st.expander(
-                        f"Show {category} data table",
-                        expanded=False,
-                    ):
-                        st.dataframe(
-                            table_df,
-                            width="stretch",
-                            hide_index=True,
-                        )
-
-            # DISPATCH
-
-            elif result_view == "Dispatch":
-                dispatch_category = st.radio(
-                    "Select dispatch category",
-                    get_available_dispatch_categories(),
-                    horizontal=True,
+                st.dataframe(
+                    scenario_df,
+                    hide_index=True,
+                    width="stretch",
                 )
 
-                dispatch_scope = st.radio(
-                    "Select dispatch aggregation",
-                    ["National", "By state"],
-                    horizontal=True,
+                available_runs = list(st.session_state.solved_networks.keys())
+                label_map = st.session_state.scenario_labels
+
+                run_lookup = {label_map.get(run, run): run for run in available_runs}
+
+                selected_labels = st.multiselect(
+                    "Select solved scenarios",
+                    list(run_lookup.keys()),
+                    default=list(run_lookup.keys()),
+                    width="stretch",
                 )
 
-                resample_options = [
-                    "Original",
-                    "Daily mean",
-                    "Weekly mean",
-                ]
+                selected_runs = [run_lookup[label] for label in selected_labels]
 
-                APP_DIR = Path(__file__).resolve().parent
-                shape_path = APP_DIR / "data" / "shapes" / "australia_states.geojson"
-
-                states = None
-                selected_state = None
-
-                if dispatch_scope == "By state":
-                    try:
-                        states = gpd.read_file(shape_path)
-                        state_dispatch_all = compute_dispatch_by_carrier_and_state(
-                            st.session_state.solved_networks[selected_runs[0]],
-                            dispatch_category,
-                            states,
-                        )
-
-                        available_states = sorted(
-                            state_dispatch_all["state"].dropna().unique()
-                        )
-
-                        selected_state = st.selectbox(
-                            "Select state",
-                            available_states,
-                        )
-                    except Exception as exc:
-                        st.error(f"Could not load state shapes: {exc}")
-                        st.stop()
-
-                for dispatch_run in selected_runs:
-                    dispatch_label = label_map.get(
-                        dispatch_run,
-                        dispatch_run,
-                    )
-
-                    n_dispatch = st.session_state.solved_networks[dispatch_run]
-
-                    if dispatch_scope == "National":
-                        dispatch_df = compute_dispatch_by_carrier(
-                            n_dispatch,
-                            dispatch_category,
-                        )
-
-                    else:
-                        state_dispatch = compute_dispatch_by_carrier_and_state(
-                            n_dispatch,
-                            dispatch_category,
-                            states,
-                        )
-
-                        if state_dispatch.empty:
-                            dispatch_df = pd.DataFrame()
-
-                        else:
-                            dispatch_df = (
-                                state_dispatch[
-                                    state_dispatch["state"] == selected_state
-                                ]
-                                .drop(columns=["state"])
-                                .set_index("snapshot")
-                            )
-
-                            dispatch_df.index = pd.to_datetime(dispatch_df.index)
-
-                    n_snapshots = len(dispatch_df)
-
-                    if n_snapshots <= 100:
-                        default_index = 0
-                    elif n_snapshots <= 500:
-                        default_index = 1
-                    else:
-                        default_index = 2
-
-                    dispatch_resample = st.selectbox(
-                        f"Resample dispatch visualization for scenario {dispatch_label}",
-                        resample_options,
-                        index=default_index,
-                        key=f"dispatch_resample_{dispatch_label}_{dispatch_category}_{dispatch_scope}_{selected_state}",
-                    )
-
-                    y_label = "GW" if dispatch_category == "Electricity" else "kt"
-
-                    if dispatch_scope == "National":
-                        st.markdown(f"### Scenario {dispatch_label}")
-                    else:
-                        st.markdown(f"### Scenario {dispatch_label} - {selected_state}")
-
-                    if dispatch_df.empty:
-                        st.warning(
-                            f"No dispatch data found for {dispatch_category}"
-                            + (
-                                f" in {selected_state}."
-                                if dispatch_scope == "By state"
-                                else "."
-                            )
-                        )
-                        continue
-
-                    plot_dispatch_df = dispatch_df.copy()
-
-                    if dispatch_resample == "Daily mean":
-                        plot_dispatch_df = plot_dispatch_df.resample("D").mean()
-
-                    elif dispatch_resample == "Weekly mean":
-                        plot_dispatch_df = plot_dispatch_df.resample("W").mean()
-
-                    plot_df = plot_dispatch_df.reset_index().melt(
-                        id_vars=(plot_dispatch_df.index.name or "index"),
-                        var_name="Technology",
-                        value_name="Value",
-                    )
-
-                    time_col = plot_dispatch_df.index.name or "index"
-
-                    tech_totals = plot_df.groupby("Technology")["Value"].sum()
-
-                    shown_techs = [
-                        tech
-                        for tech in DISPATCH_COLORS
-                        if tech in tech_totals.index and tech_totals[tech] > 0
-                    ]
-
-                    chart = (
-                        alt.Chart(plot_df)
-                        .mark_area()
-                        .encode(
-                            x=alt.X(
-                                f"{time_col}:T",
-                                title="Snapshot",
-                            ),
-                            y=alt.Y(
-                                "Value:Q",
-                                stack="zero",
-                                title=y_label,
-                            ),
-                            color=alt.Color(
-                                "Technology:N",
-                                title="Technology",
-                                scale=alt.Scale(
-                                    domain=shown_techs,
-                                    range=[DISPATCH_COLORS[t] for t in shown_techs],
-                                ),
-                            ),
-                            tooltip=[
-                                alt.Tooltip(
-                                    f"{time_col}:T",
-                                    title="Snapshot",
-                                ),
-                                alt.Tooltip("Technology:N"),
-                                alt.Tooltip(
-                                    "Value:Q",
-                                    format=",.2f",
-                                ),
-                            ],
-                        )
-                        .properties(height=600)
-                    )
-
-                    st.altair_chart(chart, width="stretch")
-
-                    annual_table = compute_dispatch_annual_totals(
-                        n_dispatch,
-                        dispatch_df,
-                        dispatch_category,
-                    )
-
-                    with st.expander(
-                        f"Show {dispatch_category} annual totals for scenario {dispatch_label}",
-                        expanded=False,
-                    ):
-                        st.dataframe(
-                            annual_table,
-                            width="stretch",
-                            hide_index=True,
-                        )
-
-            # COMMODITY COST MAPS
-
-            elif result_view == "Commodity cost maps":
-                cost_map = st.radio(
-                    "Select cost map",
+                st.write("")
+                result_view = st.radio(
+                    "Select result view",
                     [
-                        "electricity (LCOE)",
-                        "e-hydrogen (LCOH)",
-                        "e-ammonia (LCOA)",
-                        "e-methanol (LCOM)",
+                        "Commodity cost maps",
+                        "Installed capacity",
+                        "Dispatch",
+                        "System costs",
+                        # "Technical comparison",
+                        "Economic comparison",
                     ],
                     horizontal=True,
                 )
 
-                APP_DIR = Path(__file__).resolve().parent
+                if selected_runs:
+                    selected_networks = {
+                        label_map.get(run, run): st.session_state.solved_networks[run]
+                        for run in selected_runs
+                    }
 
-                shape_path = APP_DIR / "data" / "shapes" / "australia_states.geojson"
+                    st.subheader(result_view)
 
-                try:
-                    states = gpd.read_file(shape_path)
+                    # INSTALLED CAPACITY
 
-                    state_maps = []
-
-                    for cost_run in selected_runs:
-                        cost_label = label_map.get(cost_run, cost_run)
-                        n_cost = st.session_state.solved_networks[cost_run]
-
-                        if cost_map == "electricity (LCOE)":
-                            cost_df, _ = compute_lcoe_by_bus(n_cost)
-                            cost_col = "weighted_lcoe"
-                            weight_col = "dispatch_twh"
-                            output_col = "state_weighted_lcoe"
-                            cbar_label = "Generation-weighted LCOE (AUD/MWh)"
-                            empty_msg = f"No LCOE data found for scenario {cost_label}."
-                            table_title = (
-                                f"Show state-level LCOE table for scenario {cost_label}"
-                            )
-                            rename_cols = {
-                                "STATE_NAME": "State",
-                                output_col: "Generation-weighted LCOE (AUD/MWh)",
-                                weight_col: "Dispatch (TWh)",
-                            }
-
-                        elif cost_map == "e-hydrogen (LCOH)":
-                            cost_df, _ = compute_lcoh_by_bus(n_cost)
-                            cost_col = "weighted_lcoh_aud_per_kg"
-                            weight_col = "h2_dispatch_kt"
-                            output_col = "state_weighted_lcoh_aud_per_kg"
-                            cbar_label = "Production-weighted LCOH (AUD/kg H2)"
-                            empty_msg = f"No grid H2 production found for scenario {cost_label}."
-                            table_title = (
-                                f"Show state-level LCOH table for scenario {cost_label}"
-                            )
-                            rename_cols = {
-                                "STATE_NAME": "State",
-                                output_col: "Production-weighted LCOH (AUD/kg H2)",
-                                weight_col: "Grid H2 production (kt H2)",
-                            }
-
-                        elif cost_map == "e-ammonia (LCOA)":
-                            cost_df, _ = compute_lco_ammonia_by_bus(n_cost)
-                            cost_col = "weighted_lco_ammonia_aud_per_tonne"
-                            weight_col = "production_kt"
-                            output_col = "state_weighted_lco_ammonia_aud_per_tonne"
-                            cbar_label = "Production-weighted LCO ammonia (AUD/t NH3)"
-                            empty_msg = f"No e-ammonia production found for scenario {cost_label}."
-                            table_title = f"Show state-level e-ammonia cost table for scenario {cost_label}"
-                            rename_cols = {
-                                "STATE_NAME": "State",
-                                output_col: "Production-weighted LCO ammonia (AUD/t NH3)",
-                                weight_col: "e-ammonia production (kt NH3)",
-                            }
-
-                        elif cost_map == "e-methanol (LCOM)":
-                            cost_df, _ = compute_lco_methanol_by_bus(n_cost)
-                            cost_col = "weighted_lco_methanol_aud_per_tonne"
-                            weight_col = "production_kt"
-                            output_col = "state_weighted_lco_methanol_aud_per_tonne"
-                            cbar_label = "Production-weighted LCOMeOH (AUD/t MeOH)"
-                            empty_msg = f"No e-methanol production found for scenario {cost_label}."
-                            table_title = f"Show state-level e-methanol cost table for scenario {cost_label}"
-                            rename_cols = {
-                                "STATE_NAME": "State",
-                                output_col: "Production-weighted LCOMeOH (AUD/t MeOH)",
-                                weight_col: "e-methanol production (kt MeOH)",
-                            }
-
-                        if cost_df.empty:
-                            state_maps.append((cost_label, None, empty_msg, None, None))
-                            continue
-
-                        state_costs = aggregate_node_costs_by_state(
-                            node_df=cost_df,
-                            states=states,
-                            cost_col=cost_col,
-                            weight_col=weight_col,
-                            output_cost_col=output_col,
+                    if result_view == "Installed capacity":
+                        category = st.radio(
+                            "Select result category",
+                            get_available_result_categories(),
+                            horizontal=True,
                         )
 
-                        state_maps.append(
-                            (
+                        if category == "Electricity":
+                            cap_df = compute_capacity_by_carrier(
+                                selected_networks,
+                                category,
+                            )
+                            y_label = "GW"
+                            result_title = "Electricity - Installed capacity"
+
+                        elif category == "CO2 capture":
+                            cap_df = compute_annual_flow_by_carrier(
+                                selected_networks,
+                                category,
+                                MWH_PER_TONNE,
+                            )
+                            y_label = "Mtpa"
+                            result_title = "CO2 capture - Annual capture"
+
+                        else:
+                            cap_df = compute_annual_flow_by_carrier(
+                                selected_networks,
+                                category,
+                                MWH_PER_TONNE,
+                            )
+                            y_label = "Mtpa"
+                            result_title = f"{category} - Annual production capacity"
+
+                        st.subheader(result_title)
+
+                        if cap_df.empty:
+                            st.warning(f"No result data found for {category}.")
+
+                        else:
+                            chart_df = cap_df.pivot_table(
+                                index="scenario",
+                                columns="carrier",
+                                values="value",
+                                aggfunc="sum",
+                                fill_value=0.0,
+                            )
+
+                            plot_df = chart_df.reset_index().melt(
+                                id_vars="scenario",
+                                var_name="Technology",
+                                value_name="Value",
+                            )
+
+                            tech_totals = plot_df.groupby("Technology")["Value"].sum()
+
+                            shown_techs = [
+                                tech
+                                for tech in DISPATCH_COLORS
+                                if tech in tech_totals.index and tech_totals[tech] > 0
+                            ]
+
+                            chart = (
+                                alt.Chart(plot_df)
+                                .mark_bar()
+                                .encode(
+                                    x=alt.X(
+                                        "scenario:N",
+                                        title="Scenario",
+                                        axis=alt.Axis(labelAngle=0),
+                                    ),
+                                    y=alt.Y(
+                                        "Value:Q",
+                                        stack="zero",
+                                        title=y_label,
+                                    ),
+                                    color=alt.Color(
+                                        "Technology:N",
+                                        title="Technology",
+                                        scale=alt.Scale(
+                                            domain=shown_techs,
+                                            range=[DISPATCH_COLORS[t] for t in shown_techs],
+                                        ),
+                                    ),
+                                    tooltip=[
+                                        alt.Tooltip("scenario:N"),
+                                        alt.Tooltip("Technology:N"),
+                                        alt.Tooltip(
+                                            "Value:Q",
+                                            format=",.2f",
+                                        ),
+                                    ],
+                                )
+                                .properties(height=600)
+                            )
+
+                            st.altair_chart(chart, width="stretch")
+
+                            APP_DIR = Path(__file__).resolve().parent
+
+                            shape_path = (
+                                APP_DIR / "data" / "shapes" / "australia_states.geojson"
+                            )
+
+                            try:
+                                shapes = gpd.read_file(shape_path)
+
+                                map_unit = "GW" if category == "Electricity" else "Mtpa"
+
+                                for capacity_run in selected_runs:
+                                    capacity_label = label_map.get(
+                                        capacity_run,
+                                        capacity_run,
+                                    )
+
+                                    st.markdown(f"### Scenario {capacity_label}")
+
+                                    capacity_by_bus = compute_capacity_by_bus(
+                                        st.session_state.solved_networks[capacity_run],
+                                        category,
+                                    )
+
+                                    if capacity_by_bus.empty:
+                                        st.warning(
+                                            f"No mapped capacity data found for scenario {capacity_label}."
+                                        )
+                                        continue
+
+                                    n_map = st.session_state.solved_networks[capacity_run]
+
+                                    map_network = None
+
+                                    if category == "Electricity":
+                                        map_network = n_map
+
+                                    fig = plot_capacity_map_by_bus(
+                                        capacity_by_bus,
+                                        shapes,
+                                        DISPATCH_COLORS,
+                                        network=map_network,
+                                        unit=map_unit,
+                                    )
+
+                                    st.pyplot(fig, width="content")
+
+                            except Exception as exc:
+                                st.error(f"Could not build capacity map: {exc}")
+
+                            table_df = (
+                                cap_df.drop(
+                                    columns=["component"],
+                                    errors="ignore",
+                                )
+                                .pivot_table(
+                                    index=["carrier", "unit"],
+                                    columns="scenario",
+                                    values="value",
+                                    aggfunc="sum",
+                                    fill_value=0.0,
+                                )
+                                .reset_index()
+                                .rename(
+                                    columns={
+                                        "carrier": "Carrier",
+                                        "unit": "Unit",
+                                    }
+                                )
+                            )
+
+                            with st.expander(
+                                f"Show {category} data table",
+                                expanded=False,
+                            ):
+                                st.dataframe(
+                                    table_df,
+                                    width="stretch",
+                                    hide_index=True,
+                                )
+
+                    # DISPATCH
+
+                    elif result_view == "Dispatch":
+                        dispatch_category = st.radio(
+                            "Select dispatch category",
+                            get_available_dispatch_categories(),
+                            horizontal=True,
+                        )
+
+                        dispatch_scope = st.radio(
+                            "Select dispatch aggregation",
+                            ["National", "By state"],
+                            horizontal=True,
+                        )
+
+                        resample_options = [
+                            "Original",
+                            "Daily mean",
+                            "Weekly mean",
+                        ]
+
+                        APP_DIR = Path(__file__).resolve().parent
+                        shape_path = APP_DIR / "data" / "shapes" / "australia_states.geojson"
+
+                        states = None
+                        selected_state = None
+
+                        if dispatch_scope == "By state":
+                            try:
+                                states = gpd.read_file(shape_path)
+                                state_dispatch_all = compute_dispatch_by_carrier_and_state(
+                                    st.session_state.solved_networks[selected_runs[0]],
+                                    dispatch_category,
+                                    states,
+                                )
+
+                                available_states = sorted(
+                                    state_dispatch_all["state"].dropna().unique()
+                                )
+
+                                selected_state = st.selectbox(
+                                    "Select state",
+                                    available_states,
+                                )
+                            except Exception as exc:
+                                st.error(f"Could not load state shapes: {exc}")
+                                st.stop()
+
+                        for dispatch_run in selected_runs:
+                            dispatch_label = label_map.get(
+                                dispatch_run,
+                                dispatch_run,
+                            )
+
+                            n_dispatch = st.session_state.solved_networks[dispatch_run]
+
+                            if dispatch_scope == "National":
+                                dispatch_df = compute_dispatch_by_carrier(
+                                    n_dispatch,
+                                    dispatch_category,
+                                )
+
+                            else:
+                                state_dispatch = compute_dispatch_by_carrier_and_state(
+                                    n_dispatch,
+                                    dispatch_category,
+                                    states,
+                                )
+
+                                if state_dispatch.empty:
+                                    dispatch_df = pd.DataFrame()
+
+                                else:
+                                    dispatch_df = (
+                                        state_dispatch[
+                                            state_dispatch["state"] == selected_state
+                                        ]
+                                        .drop(columns=["state"])
+                                        .set_index("snapshot")
+                                    )
+
+                                    dispatch_df.index = pd.to_datetime(dispatch_df.index)
+
+                            n_snapshots = len(dispatch_df)
+
+                            if n_snapshots <= 100:
+                                default_index = 0
+                            elif n_snapshots <= 500:
+                                default_index = 1
+                            else:
+                                default_index = 2
+
+                            dispatch_resample = st.selectbox(
+                                f"Resample dispatch visualization for scenario {dispatch_label}",
+                                resample_options,
+                                index=default_index,
+                                key=f"dispatch_resample_{dispatch_label}_{dispatch_category}_{dispatch_scope}_{selected_state}",
+                            )
+
+                            y_label = "GW" if dispatch_category == "Electricity" else "kt"
+
+                            if dispatch_scope == "National":
+                                st.markdown(f"### Scenario {dispatch_label}")
+                            else:
+                                st.markdown(f"### Scenario {dispatch_label} - {selected_state}")
+
+                            if dispatch_df.empty:
+                                st.warning(
+                                    f"No dispatch data found for {dispatch_category}"
+                                    + (
+                                        f" in {selected_state}."
+                                        if dispatch_scope == "By state"
+                                        else "."
+                                    )
+                                )
+                                continue
+
+                            plot_dispatch_df = dispatch_df.copy()
+
+                            if dispatch_resample == "Daily mean":
+                                plot_dispatch_df = plot_dispatch_df.resample("D").mean()
+
+                            elif dispatch_resample == "Weekly mean":
+                                plot_dispatch_df = plot_dispatch_df.resample("W").mean()
+
+                            plot_df = plot_dispatch_df.reset_index().melt(
+                                id_vars=(plot_dispatch_df.index.name or "index"),
+                                var_name="Technology",
+                                value_name="Value",
+                            )
+
+                            time_col = plot_dispatch_df.index.name or "index"
+
+                            tech_totals = plot_df.groupby("Technology")["Value"].sum()
+
+                            shown_techs = [
+                                tech
+                                for tech in DISPATCH_COLORS
+                                if tech in tech_totals.index and tech_totals[tech] > 0
+                            ]
+
+                            chart = (
+                                alt.Chart(plot_df)
+                                .mark_area()
+                                .encode(
+                                    x=alt.X(
+                                        f"{time_col}:T",
+                                        title="Snapshot",
+                                    ),
+                                    y=alt.Y(
+                                        "Value:Q",
+                                        stack="zero",
+                                        title=y_label,
+                                    ),
+                                    color=alt.Color(
+                                        "Technology:N",
+                                        title="Technology",
+                                        scale=alt.Scale(
+                                            domain=shown_techs,
+                                            range=[DISPATCH_COLORS[t] for t in shown_techs],
+                                        ),
+                                    ),
+                                    tooltip=[
+                                        alt.Tooltip(
+                                            f"{time_col}:T",
+                                            title="Snapshot",
+                                        ),
+                                        alt.Tooltip("Technology:N"),
+                                        alt.Tooltip(
+                                            "Value:Q",
+                                            format=",.2f",
+                                        ),
+                                    ],
+                                )
+                                .properties(height=600)
+                            )
+
+                            st.altair_chart(chart, width="stretch")
+
+                            annual_table = compute_dispatch_annual_totals(
+                                n_dispatch,
+                                dispatch_df,
+                                dispatch_category,
+                            )
+
+                            with st.expander(
+                                f"Show {dispatch_category} annual totals for scenario {dispatch_label}",
+                                expanded=False,
+                            ):
+                                st.dataframe(
+                                    annual_table,
+                                    width="stretch",
+                                    hide_index=True,
+                                )
+
+                    # COMMODITY COST MAPS
+
+                    elif result_view == "Commodity cost maps":
+                        cost_map = st.radio(
+                            "Select cost map",
+                            [
+                                "electricity (LCOE)",
+                                "e-hydrogen (LCOH)",
+                                "e-ammonia (LCOA)",
+                                "e-methanol (LCOM)",
+                            ],
+                            horizontal=True,
+                        )
+
+                        APP_DIR = Path(__file__).resolve().parent
+
+                        shape_path = APP_DIR / "data" / "shapes" / "australia_states.geojson"
+
+                        try:
+                            states = gpd.read_file(shape_path)
+
+                            state_maps = []
+
+                            for cost_run in selected_runs:
+                                cost_label = label_map.get(cost_run, cost_run)
+                                n_cost = st.session_state.solved_networks[cost_run]
+
+                                if cost_map == "electricity (LCOE)":
+                                    cost_df, _ = compute_lcoe_by_bus(n_cost)
+                                    cost_col = "weighted_lcoe"
+                                    weight_col = "dispatch_twh"
+                                    output_col = "state_weighted_lcoe"
+                                    cbar_label = "Generation-weighted LCOE (AUD/MWh)"
+                                    empty_msg = f"No LCOE data found for scenario {cost_label}."
+                                    table_title = (
+                                        f"Show state-level LCOE table for scenario {cost_label}"
+                                    )
+                                    rename_cols = {
+                                        "STATE_NAME": "State",
+                                        output_col: "Generation-weighted LCOE (AUD/MWh)",
+                                        weight_col: "Dispatch (TWh)",
+                                    }
+
+                                elif cost_map == "e-hydrogen (LCOH)":
+                                    cost_df, _ = compute_lcoh_by_bus(n_cost)
+                                    cost_col = "weighted_lcoh_aud_per_kg"
+                                    weight_col = "h2_dispatch_kt"
+                                    output_col = "state_weighted_lcoh_aud_per_kg"
+                                    cbar_label = "Production-weighted LCOH (AUD/kg H2)"
+                                    empty_msg = f"No grid H2 production found for scenario {cost_label}."
+                                    table_title = (
+                                        f"Show state-level LCOH table for scenario {cost_label}"
+                                    )
+                                    rename_cols = {
+                                        "STATE_NAME": "State",
+                                        output_col: "Production-weighted LCOH (AUD/kg H2)",
+                                        weight_col: "Grid H2 production (kt H2)",
+                                    }
+
+                                elif cost_map == "e-ammonia (LCOA)":
+                                    cost_df, _ = compute_lco_ammonia_by_bus(n_cost)
+                                    cost_col = "weighted_lco_ammonia_aud_per_tonne"
+                                    weight_col = "production_kt"
+                                    output_col = "state_weighted_lco_ammonia_aud_per_tonne"
+                                    cbar_label = "Production-weighted LCO ammonia (AUD/t NH3)"
+                                    empty_msg = f"No e-ammonia production found for scenario {cost_label}."
+                                    table_title = f"Show state-level e-ammonia cost table for scenario {cost_label}"
+                                    rename_cols = {
+                                        "STATE_NAME": "State",
+                                        output_col: "Production-weighted LCO ammonia (AUD/t NH3)",
+                                        weight_col: "e-ammonia production (kt NH3)",
+                                    }
+
+                                elif cost_map == "e-methanol (LCOM)":
+                                    cost_df, _ = compute_lco_methanol_by_bus(n_cost)
+                                    cost_col = "weighted_lco_methanol_aud_per_tonne"
+                                    weight_col = "production_kt"
+                                    output_col = "state_weighted_lco_methanol_aud_per_tonne"
+                                    cbar_label = "Production-weighted LCOMeOH (AUD/t MeOH)"
+                                    empty_msg = f"No e-methanol production found for scenario {cost_label}."
+                                    table_title = f"Show state-level e-methanol cost table for scenario {cost_label}"
+                                    rename_cols = {
+                                        "STATE_NAME": "State",
+                                        output_col: "Production-weighted LCOMeOH (AUD/t MeOH)",
+                                        weight_col: "e-methanol production (kt MeOH)",
+                                    }
+
+                                if cost_df.empty:
+                                    state_maps.append((cost_label, None, empty_msg, None, None))
+                                    continue
+
+                                state_costs = aggregate_node_costs_by_state(
+                                    node_df=cost_df,
+                                    states=states,
+                                    cost_col=cost_col,
+                                    weight_col=weight_col,
+                                    output_cost_col=output_col,
+                                )
+
+                                state_maps.append(
+                                    (
+                                        cost_label,
+                                        state_costs,
+                                        empty_msg,
+                                        table_title,
+                                        rename_cols,
+                                    )
+                                )
+
+                            valid_state_maps = [
+                                state_costs
+                                for _, state_costs, _, _, _ in state_maps
+                                if state_costs is not None
+                                and output_col in state_costs.columns
+                                and not state_costs[output_col].dropna().empty
+                            ]
+
+                            if not valid_state_maps:
+                                st.warning(
+                                    "No valid cost data available for the selected scenarios."
+                                )
+                                st.stop()
+
+                            all_values = pd.concat(
+                                [
+                                    state_costs[output_col].dropna()
+                                    for state_costs in valid_state_maps
+                                ],
+                                ignore_index=True,
+                            )
+
+                            vmin = all_values.quantile(0.05)
+                            vmax = all_values.quantile(0.95)
+
+                            for (
                                 cost_label,
                                 state_costs,
                                 empty_msg,
                                 table_title,
                                 rename_cols,
+                            ) in state_maps:
+                                st.markdown(f"### Scenario {cost_label}")
+
+                                if state_costs is None:
+                                    st.warning(empty_msg)
+                                    continue
+
+                                fig = plot_state_cost_map(
+                                    state_costs=state_costs,
+                                    value_col=output_col,
+                                    colorbar_label=cbar_label,
+                                    vmin=vmin,
+                                    vmax=vmax,
+                                )
+
+                                st.pyplot(fig, width="content")
+
+                                table_cols = ["STATE_NAME", output_col, weight_col]
+
+                                with st.expander(
+                                    table_title,
+                                    expanded=False,
+                                ):
+                                    st.dataframe(
+                                        state_costs[table_cols]
+                                        .dropna(subset=[output_col])
+                                        .round(2)
+                                        .rename(columns=rename_cols),
+                                        hide_index=True,
+                                        width="stretch",
+                                    )
+
+                        except Exception as exc:
+                            st.error(f"Could not build cost map: {exc}")
+
+                    # SYSTEM COSTS
+
+                    elif result_view == "System costs":
+                        system_cost_type = st.radio(
+                            "Select system cost type",
+                            [
+                                "Capital expenditure",
+                                "Operational expenditure",
+                            ],
+                            horizontal=True,
+                        )
+
+                        df_system = build_system_cost_table(selected_networks)
+
+                        df_plot = (
+                            df_system[df_system["cost_type"] == system_cost_type]
+                            .groupby(
+                                ["scenario", "tech_label"],
+                                as_index=False,
+                            )["cost_billion"]
+                            .sum()
+                        )
+
+                        active_categories = (
+                            df_plot.groupby("tech_label")["cost_billion"]
+                            .sum()
+                            .loc[lambda s: s.abs() > 1e-6]
+                            .index
+                        )
+
+                        categories = [c for c in renamed_tech_colors if c in active_categories]
+
+                        df_plot = df_plot[df_plot["tech_label"].isin(categories)]
+
+                        chart = (
+                            alt.Chart(df_plot)
+                            .mark_bar()
+                            .encode(
+                                x=alt.X(
+                                    "scenario:N",
+                                    title="Scenario",
+                                    axis=alt.Axis(labelAngle=0),
+                                ),
+                                y=alt.Y(
+                                    "cost_billion:Q",
+                                    title="Annual system cost (Billion AUD/year)",
+                                    stack="zero",
+                                ),
+                                color=alt.Color(
+                                    "tech_label:N",
+                                    title="Technology",
+                                    scale=alt.Scale(
+                                        domain=categories,
+                                        range=[renamed_tech_colors[c] for c in categories],
+                                    ),
+                                ),
+                                tooltip=[
+                                    "scenario",
+                                    "tech_label",
+                                    alt.Tooltip(
+                                        "cost_billion:Q",
+                                        format=",.2f",
+                                    ),
+                                ],
+                            )
+                            .properties(height=600)
+                        )
+
+                        st.altair_chart(chart, width="stretch")
+
+                        summary_table = (
+                            df_system[df_system["cost_type"] == system_cost_type]
+                            .pivot_table(
+                                index=["macro_category", "tech_label"],
+                                columns="scenario",
+                                values="cost_billion",
+                                aggfunc="sum",
+                                fill_value=0.0,
+                            )
+                            .reset_index()
+                            .rename(
+                                columns={
+                                    "macro_category": "Macro category",
+                                    "tech_label": "Technology",
+                                }
                             )
                         )
 
-                    valid_state_maps = [
-                        state_costs
-                        for _, state_costs, _, _, _ in state_maps
-                        if state_costs is not None
-                        and output_col in state_costs.columns
-                        and not state_costs[output_col].dropna().empty
-                    ]
+                        scenario_cols = [
+                            c
+                            for c in summary_table.columns
+                            if c not in ["Macro category", "Technology"]
+                        ]
 
-                    if not valid_state_maps:
-                        st.warning(
-                            "No valid cost data available for the selected scenarios."
-                        )
-                        st.stop()
-
-                    all_values = pd.concat(
-                        [
-                            state_costs[output_col].dropna()
-                            for state_costs in valid_state_maps
-                        ],
-                        ignore_index=True,
-                    )
-
-                    vmin = all_values.quantile(0.05)
-                    vmax = all_values.quantile(0.95)
-
-                    for (
-                        cost_label,
-                        state_costs,
-                        empty_msg,
-                        table_title,
-                        rename_cols,
-                    ) in state_maps:
-                        st.markdown(f"### Scenario {cost_label}")
-
-                        if state_costs is None:
-                            st.warning(empty_msg)
-                            continue
-
-                        fig = plot_state_cost_map(
-                            state_costs=state_costs,
-                            value_col=output_col,
-                            colorbar_label=cbar_label,
-                            vmin=vmin,
-                            vmax=vmax,
-                        )
-
-                        st.pyplot(fig, width="content")
-
-                        table_cols = ["STATE_NAME", output_col, weight_col]
+                        summary_table = summary_table[
+                            (summary_table[scenario_cols].abs().sum(axis=1) > 0)
+                        ]
 
                         with st.expander(
-                            table_title,
+                            f"Show {system_cost_type.lower()} summary table",
                             expanded=False,
                         ):
                             st.dataframe(
-                                state_costs[table_cols]
-                                .dropna(subset=[output_col])
-                                .round(2)
-                                .rename(columns=rename_cols),
+                                summary_table.round(3),
                                 hide_index=True,
                                 width="stretch",
                             )
 
-                except Exception as exc:
-                    st.error(f"Could not build cost map: {exc}")
+                        detailed_table = (
+                            df_system[df_system["cost_type"] == system_cost_type]
+                            .pivot_table(
+                                index=[
+                                    "macro_category",
+                                    "tech_label",
+                                    "raw_technology",
+                                ],
+                                columns="scenario",
+                                values="cost_billion",
+                                aggfunc="sum",
+                                fill_value=0.0,
+                            )
+                            .reset_index()
+                            .rename(
+                                columns={
+                                    "macro_category": "Macro category",
+                                    "tech_label": "Category",
+                                    "raw_technology": "Technology",
+                                }
+                            )
+                        )
 
-            # SYSTEM COSTS
+                        scenario_cols = [
+                            c
+                            for c in detailed_table.columns
+                            if c not in ["Macro category", "Category", "Technology"]
+                        ]
 
-            elif result_view == "System costs":
-                system_cost_type = st.radio(
-                    "Select system cost type",
-                    [
-                        "Capital expenditure",
-                        "Operational expenditure",
-                    ],
-                    horizontal=True,
+                        detailed_table = detailed_table[
+                            (detailed_table[scenario_cols].abs().sum(axis=1) > 0)
+                        ]
+
+                        with st.expander(
+                            f"Show detailed {system_cost_type.lower()} table",
+                            expanded=False,
+                        ):
+                            st.dataframe(
+                                detailed_table.round(3),
+                                hide_index=True,
+                                width="stretch",
+                            )
+
+                # ECONOMIC COMPARISON
+
+                if result_view == "Economic comparison":
+                    if st.session_state.results is None:
+                        st.info("Run an optimization first to show the economic comparison.")
+                        st.stop()
+
+                    df = st.session_state.results
+                    df = df.rename(columns=label_map)
+                    df = df / 1e3
+
+                    df = df[df.index.get_level_values(0).str.contains("Economics")].round(1)
+
+                    df = df.reset_index().drop(columns=["component"]).set_index("carrier")
+
+                    st.bar_chart(
+                        df.T,
+                        x_label="Scenario",
+                        y_label="Annual Cost (Million AUD)",
+                        horizontal=True,
+                    )
+
+            else:
+                st.info(
+                    "Please load a network via the left sidebar and run an optimization to see results here ..."
                 )
 
-                df_system = build_system_cost_table(selected_networks)
-
-                df_plot = (
-                    df_system[df_system["cost_type"] == system_cost_type]
-                    .groupby(
-                        ["scenario", "tech_label"],
-                        as_index=False,
-                    )["cost_billion"]
-                    .sum()
-                )
-
-                active_categories = (
-                    df_plot.groupby("tech_label")["cost_billion"]
-                    .sum()
-                    .loc[lambda s: s.abs() > 1e-6]
-                    .index
-                )
-
-                categories = [c for c in renamed_tech_colors if c in active_categories]
-
-                df_plot = df_plot[df_plot["tech_label"].isin(categories)]
-
-                chart = (
-                    alt.Chart(df_plot)
-                    .mark_bar()
-                    .encode(
-                        x=alt.X(
-                            "scenario:N",
-                            title="Scenario",
-                            axis=alt.Axis(labelAngle=0),
-                        ),
-                        y=alt.Y(
-                            "cost_billion:Q",
-                            title="Annual system cost (Billion AUD/year)",
-                            stack="zero",
-                        ),
-                        color=alt.Color(
-                            "tech_label:N",
-                            title="Technology",
-                            scale=alt.Scale(
-                                domain=categories,
-                                range=[renamed_tech_colors[c] for c in categories],
-                            ),
-                        ),
-                        tooltip=[
-                            "scenario",
-                            "tech_label",
-                            alt.Tooltip(
-                                "cost_billion:Q",
-                                format=",.2f",
-                            ),
-                        ],
-                    )
-                    .properties(height=600)
-                )
-
-                st.altair_chart(chart, width="stretch")
-
-                summary_table = (
-                    df_system[df_system["cost_type"] == system_cost_type]
-                    .pivot_table(
-                        index=["macro_category", "tech_label"],
-                        columns="scenario",
-                        values="cost_billion",
-                        aggfunc="sum",
-                        fill_value=0.0,
-                    )
-                    .reset_index()
-                    .rename(
-                        columns={
-                            "macro_category": "Macro category",
-                            "tech_label": "Technology",
-                        }
-                    )
-                )
-
-                scenario_cols = [
-                    c
-                    for c in summary_table.columns
-                    if c not in ["Macro category", "Technology"]
-                ]
-
-                summary_table = summary_table[
-                    (summary_table[scenario_cols].abs().sum(axis=1) > 0)
-                ]
-
-                with st.expander(
-                    f"Show {system_cost_type.lower()} summary table",
-                    expanded=False,
-                ):
-                    st.dataframe(
-                        summary_table.round(3),
-                        hide_index=True,
-                        width="stretch",
-                    )
-
-                detailed_table = (
-                    df_system[df_system["cost_type"] == system_cost_type]
-                    .pivot_table(
-                        index=[
-                            "macro_category",
-                            "tech_label",
-                            "raw_technology",
-                        ],
-                        columns="scenario",
-                        values="cost_billion",
-                        aggfunc="sum",
-                        fill_value=0.0,
-                    )
-                    .reset_index()
-                    .rename(
-                        columns={
-                            "macro_category": "Macro category",
-                            "tech_label": "Category",
-                            "raw_technology": "Technology",
-                        }
-                    )
-                )
-
-                scenario_cols = [
-                    c
-                    for c in detailed_table.columns
-                    if c not in ["Macro category", "Category", "Technology"]
-                ]
-
-                detailed_table = detailed_table[
-                    (detailed_table[scenario_cols].abs().sum(axis=1) > 0)
-                ]
-
-                with st.expander(
-                    f"Show detailed {system_cost_type.lower()} table",
-                    expanded=False,
-                ):
-                    st.dataframe(
-                        detailed_table.round(3),
-                        hide_index=True,
-                        width="stretch",
-                    )
-
-        # ECONOMIC COMPARISON
-
-        if result_view == "Economic comparison":
-            if st.session_state.results is None:
-                st.info("Run an optimization first to show the economic comparison.")
-                st.stop()
-
-            df = st.session_state.results
-            df = df.rename(columns=label_map)
-            df = df / 1e3
-
-            df = df[df.index.get_level_values(0).str.contains("Economics")].round(1)
-
-            df = df.reset_index().drop(columns=["component"]).set_index("carrier")
-
-            st.bar_chart(
-                df.T,
-                x_label="Scenario",
-                y_label="Annual Cost (Million AUD)",
-                horizontal=True,
-            )
+                st.write("""
+                    After running an optimization, you will see a detailed breakdown of the expanded capacities and economic outcomes for each technology, allowing you to assess the impact of your parameter adjustments on the network's performance and costs.
+                    """)
 
     else:
         st.info(
@@ -2553,7 +2564,7 @@ with t_insurance:
     """)
 
     try:
-        with st.spinner("Downloading precomputed insurance scenarios..."):
+        with st.spinner("Downloading precomputed insurance scenarios (depending on your internet speed this might take some minutes)..."):
             insurance_networks = load_precomputed_insurance_scenarios(nodes)
 
     except Exception as exc:

--- a/streamlit/app.py
+++ b/streamlit/app.py
@@ -142,6 +142,10 @@ T_PER_GJ_DIESEL = 42.8  # or MT per PJ
 DEFAULT_E_SHARE = 0.50
 DEFAULT_E_SHARE_PRODUCTION = 0.30
 
+INSURANCE_SCENARIO_RECORD_ID = "20559877"
+INSURANCE_SCENARIO_URL = f"https://zenodo.org/records/{INSURANCE_SCENARIO_RECORD_ID}"
+GREEN_LOCAL_PRODUCTION_SHARES = [20, 40, 60, 80, 100]
+
 # ----- diesel / methanol demand
 # source: Department of Climate Change, Energy, the Environment and Water, Australian Energy Statistics, Table F, August 2025
 # last available data for 2023-24
@@ -412,6 +416,80 @@ def build_scenario_summary(
             f"e-methanol: {demand['e_methanol']:.1f} Mtpa",
         ]
     )
+
+
+def get_network_demand_mtpa(network: pypsa.Network, demand_key: str) -> float:
+    """Return annual demand for a demand entry in Mtpa."""
+    loads = get_loads_for_demand_entry(
+        network,
+        carriers=load_data[demand_key]["carriers"],
+        loads=load_data[demand_key]["loads"],
+    )
+
+    if len(loads) == 0 or demand_key not in MWH_PER_TONNE:
+        return 0.0
+
+    available_loads = loads.intersection(network.loads_t.p.columns)
+
+    if len(available_loads) > 0:
+        annual_mwh = (
+            network.loads_t.p[available_loads]
+            .multiply(network.snapshot_weightings.generators, axis=0)
+            .sum()
+            .sum()
+        )
+    else:
+        annual_mwh = (
+            network.loads.loc[loads, "p_set"].sum()
+            * network.snapshot_weightings.generators.sum()
+        )
+
+    return annual_mwh / MWH_PER_TONNE[demand_key] / 1e6
+
+
+def load_precomputed_insurance_scenarios(nodes: int) -> dict[str, pypsa.Network]:
+    """Download and load precomputed import shock insurance scenarios from Zenodo."""
+    cache_key = f"insurance_scenarios_{nodes}n"
+
+    if cache_key in st.session_state:
+        return st.session_state[cache_key]
+
+    api_url = f"https://zenodo.org/api/records/{INSURANCE_SCENARIO_RECORD_ID}"
+    res = requests.get(api_url)
+    res.raise_for_status()
+    record = res.json()
+
+    scenario_networks = {}
+
+    for share in GREEN_LOCAL_PRODUCTION_SHARES:
+        file_name = f"AU_2030_{nodes}n_greenlocprod{share}_solved.nc"
+
+        file_info = next(
+            (f for f in record["files"] if f["key"] == file_name),
+            None,
+        )
+
+        if file_info is None:
+            raise FileNotFoundError(
+                f"Could not find {file_name} in Zenodo record "
+                f"{INSURANCE_SCENARIO_RECORD_ID}."
+            )
+
+        download_url = file_info["links"]["self"]
+        tmp_path = Path(tempfile.gettempdir()) / file_name
+
+        if not tmp_path.exists():
+            with requests.get(download_url, stream=True) as r:
+                r.raise_for_status()
+                with open(tmp_path, "wb") as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        f.write(chunk)
+
+        scenario_networks[f"greenlocprod{share}"] = pypsa.Network(tmp_path)
+
+    st.session_state[cache_key] = scenario_networks
+
+    return scenario_networks
 
 
 title = "AUS eFuels"
@@ -1623,7 +1701,7 @@ with t_optimization:
 
 # TAB RESULTS
 with t_results:
-    if len(st.session_state.solved_networks) > 0:
+    if st.session_state.n is not None or len(st.session_state.solved_networks) > 0:
         st.header("Results Explorer")
 
         if "scenario_metadata" in st.session_state:
@@ -1702,9 +1780,182 @@ with t_results:
                 "System costs",
                 # "Technical comparison",
                 "Economic comparison",
+                "Import shock insurance",
             ],
             horizontal=True,
         )
+
+        if result_view == "Import shock insurance":
+            st.info("""
+                This analysis uses precomputed optimization results downloaded from Zenodo.
+
+                It is independent from any optimization runs performed in this application and
+                does not use the default Economic Parameters, Demand Parameters or Optimization
+                settings.
+
+                The loaded network is only used to identify the network resolution
+                (10, 15 or 20 nodes) and select the corresponding precomputed scenarios.
+                """)
+            st.markdown(f"""
+                **Dataset source:** [Zenodo record {INSURANCE_SCENARIO_RECORD_ID}]({INSURANCE_SCENARIO_URL})
+
+                Scenarios included:
+                - 20% local green production
+                - 40% local green production
+                - 60% local green production
+                - 80% local green production
+                - 100% local green production
+                """)
+            if st.session_state.n is None:
+                st.info(
+                    "Please load a base network first. The loaded network is used "
+                    "to infer whether the 10, 15 or 20 node insurance scenarios "
+                    "should be downloaded."
+                )
+                st.stop()
+
+            raw_nodes = infer_network_clusters(st.session_state.n)
+
+            nodes = {
+                9: 10,
+                14: 15,
+                19: 20,
+            }.get(raw_nodes, raw_nodes)
+
+            st.markdown(f"""
+                Precomputed insurance scenarios for **{nodes} nodes** are downloaded from
+                [Zenodo]({INSURANCE_SCENARIO_URL}).
+
+                The analysis compares green local production shares of
+                20%, 40%, 60%, 80% and 100%.
+                """)
+
+            try:
+                with st.spinner("Downloading precomputed insurance scenarios..."):
+                    insurance_networks = load_precomputed_insurance_scenarios(nodes)
+
+            except Exception as exc:
+                st.error(f"Could not load precomputed insurance scenarios: {exc}")
+                st.stop()
+
+            baseline_label = st.selectbox(
+                "Select baseline scenario",
+                list(insurance_networks.keys()),
+                index=0,
+            )
+
+            diesel_shocks = st.multiselect(
+                "Diesel-equivalent import price increase (AUD/t)",
+                [0, 150, 300, 450, 600],
+                default=[0, 150, 300, 450, 600],
+            )
+
+            ammonia_shock = st.number_input(
+                "Ammonia import price increase (AUD/t NH3)",
+                min_value=0.0,
+                value=0.0,
+                step=50.0,
+            )
+
+            baseline_network = insurance_networks[baseline_label]
+            baseline_cost = baseline_network.objective / 1e6
+            baseline_meoh = get_network_demand_mtpa(
+                baseline_network,
+                "e_methanol",
+            )
+            baseline_nh3 = get_network_demand_mtpa(
+                baseline_network,
+                "e_ammonia",
+            )
+
+            rows = []
+
+            for scenario_label, scenario_network in insurance_networks.items():
+                scenario_cost = scenario_network.objective / 1e6
+
+                e_meoh = get_network_demand_mtpa(
+                    scenario_network,
+                    "e_methanol",
+                )
+                e_nh3 = get_network_demand_mtpa(
+                    scenario_network,
+                    "e_ammonia",
+                )
+
+                additional_system_cost = scenario_cost - baseline_cost
+                additional_meoh = max(e_meoh - baseline_meoh, 0.0)
+                additional_nh3 = max(e_nh3 - baseline_nh3, 0.0)
+
+                for diesel_shock in diesel_shocks:
+                    avoided_import_expenditure = (
+                        additional_meoh * 1e6 * diesel_shock
+                        + additional_nh3 * 1e6 * ammonia_shock
+                    ) / 1e6
+
+                    insurance_value = (
+                        avoided_import_expenditure - additional_system_cost
+                    )
+
+                    rows.append(
+                        {
+                            "Scenario": scenario_label,
+                            "Diesel-equivalent shock (AUD/t)": diesel_shock,
+                            "Ammonia shock (AUD/t NH3)": ammonia_shock,
+                            "System cost (MAUD/year)": scenario_cost,
+                            "Additional system cost (MAUD/year)": additional_system_cost,
+                            "Avoided import expenditure (MAUD/year)": avoided_import_expenditure,
+                            "Insurance value (MAUD/year)": insurance_value,
+                            "e-methanol demand (Mtpa)": e_meoh,
+                            "e-ammonia demand (Mtpa)": e_nh3,
+                        }
+                    )
+
+            insurance_df = pd.DataFrame(rows)
+
+            st.dataframe(
+                insurance_df.round(2),
+                hide_index=True,
+                width="stretch",
+            )
+
+            chart = (
+                alt.Chart(insurance_df)
+                .mark_line(point=True)
+                .encode(
+                    x=alt.X(
+                        "Diesel-equivalent shock (AUD/t):Q",
+                        title="Diesel-equivalent import price increase (AUD/t)",
+                    ),
+                    y=alt.Y(
+                        "Insurance value (MAUD/year):Q",
+                        title="Insurance value (MAUD/year)",
+                    ),
+                    color=alt.Color("Scenario:N", title="Scenario"),
+                    tooltip=[
+                        "Scenario:N",
+                        alt.Tooltip("Diesel-equivalent shock (AUD/t):Q"),
+                        alt.Tooltip("Ammonia shock (AUD/t NH3):Q"),
+                        alt.Tooltip("System cost (MAUD/year):Q", format=",.2f"),
+                        alt.Tooltip(
+                            "Additional system cost (MAUD/year):Q",
+                            format=",.2f",
+                        ),
+                        alt.Tooltip(
+                            "Avoided import expenditure (MAUD/year):Q",
+                            format=",.2f",
+                        ),
+                        alt.Tooltip(
+                            "Insurance value (MAUD/year):Q",
+                            format=",.2f",
+                        ),
+                    ],
+                )
+                .properties(height=500)
+            )
+
+            st.altair_chart(chart, width="stretch")
+
+            st.stop()
 
         if selected_runs:
             selected_networks = {

--- a/streamlit/app.py
+++ b/streamlit/app.py
@@ -1844,43 +1844,34 @@ with t_results:
             )
 
             diesel_shocks_l = [0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
-
-            ammonia_shock = st.number_input(
-                "Assumed ammonia import price shock (AUD/t NH3)",
-                min_value=0.0,
-                value=0.0,
-                step=50.0,
-            )
-
-            st.caption(
-                "This shock is applied to additional e-ammonia production relative to the 0% local e-fuel production reference case."
-            )
+            ammonia_shocks = [
+                0,
+                300,
+                600,
+                900,
+                1200,
+                1500,
+                1800,
+                2100,
+                2400,
+                2700,
+                3000,
+            ]
 
             baseline_network = insurance_networks[baseline_label]
             baseline_cost = baseline_network.objective / 1e6
-            baseline_meoh = get_network_demand_mtpa(
-                baseline_network,
-                "e_methanol",
-            )
-            baseline_nh3 = get_network_demand_mtpa(
-                baseline_network,
-                "e_ammonia",
-            )
+            baseline_meoh = get_network_demand_mtpa(baseline_network, "e_methanol")
+            baseline_nh3 = get_network_demand_mtpa(baseline_network, "e_ammonia")
 
-            rows = []
+            diesel_rows = []
+            ammonia_rows = []
             scenario_detail_rows = []
 
             for scenario_label, scenario_network in insurance_networks.items():
                 scenario_cost = scenario_network.objective / 1e6
 
-                e_meoh = get_network_demand_mtpa(
-                    scenario_network,
-                    "e_methanol",
-                )
-                e_nh3 = get_network_demand_mtpa(
-                    scenario_network,
-                    "e_ammonia",
-                )
+                e_meoh = get_network_demand_mtpa(scenario_network, "e_methanol")
+                e_nh3 = get_network_demand_mtpa(scenario_network, "e_ammonia")
 
                 additional_system_cost = scenario_cost - baseline_cost
                 additional_green_fuel = max(e_meoh - baseline_meoh, 0.0)
@@ -1906,20 +1897,19 @@ with t_results:
 
                 for diesel_shock_l in diesel_shocks_l:
                     diesel_shock = diesel_shock_l * 1000 / KG_PER_LITER_DIESEL
+
                     value_of_displaced_import_exposure = (
                         additional_diesel_equivalent * 1e6 * diesel_shock
-                        + additional_nh3 * 1e6 * ammonia_shock
                     ) / 1e6
 
                     net_insurance_benefit = (
                         value_of_displaced_import_exposure - additional_system_cost
                     )
 
-                    rows.append(
+                    diesel_rows.append(
                         {
                             "Scenario": scenario_display_labels[scenario_label],
                             "Assumed diesel import price increase (AUD/liter)": diesel_shock_l,
-                            "Ammonia import price increase (AUD/t NH3)": ammonia_shock,
                             "System cost (MAUD/year)": scenario_cost,
                             "Additional system cost relative to baseline (MAUD/year)": additional_system_cost,
                             "Value of displaced import exposure (MAUD/year)": value_of_displaced_import_exposure,
@@ -1927,95 +1917,149 @@ with t_results:
                         }
                     )
 
-            insurance_df = pd.DataFrame(rows)
+                for ammonia_shock in ammonia_shocks:
+                    value_of_displaced_import_exposure = (
+                        additional_nh3 * 1e6 * ammonia_shock
+                    ) / 1e6
+
+                    net_insurance_benefit = (
+                        value_of_displaced_import_exposure - additional_system_cost
+                    )
+
+                    ammonia_rows.append(
+                        {
+                            "Scenario": scenario_display_labels[scenario_label],
+                            "Assumed ammonia import price increase (AUD/t NH3)": ammonia_shock,
+                            "System cost (MAUD/year)": scenario_cost,
+                            "Additional system cost relative to baseline (MAUD/year)": additional_system_cost,
+                            "Value of displaced import exposure (MAUD/year)": value_of_displaced_import_exposure,
+                            "Net insurance benefit (MAUD/year)": net_insurance_benefit,
+                        }
+                    )
+
+            diesel_df = pd.DataFrame(diesel_rows)
+            ammonia_df = pd.DataFrame(ammonia_rows)
             scenario_detail_df = pd.DataFrame(scenario_detail_rows)
 
-            chart = (
-                alt.Chart(insurance_df)
-                .mark_line(point=True, strokeWidth=3, size=80)
-                .encode(
-                    x=alt.X(
-                        "Assumed diesel import price increase (AUD/liter):Q",
-                        title="Assumed diesel import price increase (AUD/liter)",
-                        axis=alt.Axis(
-                            labelFontSize=18,
-                            titleFontSize=20,
+            def make_insurance_chart(df, x_col, x_title):
+                return (
+                    alt.Chart(df)
+                    .mark_line(point=True, strokeWidth=3, size=80)
+                    .encode(
+                        x=alt.X(
+                            f"{x_col}:Q",
+                            title=x_title,
+                            axis=alt.Axis(labelFontSize=18, titleFontSize=20),
                         ),
-                    ),
-                    y=alt.Y(
-                        "Net insurance benefit (MAUD/year):Q",
-                        title="Net insurance benefit (MAUD/year)",
-                        axis=alt.Axis(
-                            labelFontSize=18,
-                            titleFontSize=20,
-                        ),
-                    ),
-                    color=alt.Color(
-                        "Scenario:N",
-                        title="Local e-fuel production share",
-                        scale=alt.Scale(
-                            domain=["0%", "20%", "40%", "60%", "80%", "100%"],
-                        ),
-                        legend=alt.Legend(
-                            orient="bottom",
-                            direction="horizontal",
-                            columns=6,
-                            labelFontSize=18,
-                            titleFontSize=20,
-                            labelLimit=0,
-                            titleLimit=0,
-                        ),
-                    ),
-                    tooltip=[
-                        "Scenario:N",
-                        alt.Tooltip(
-                            "Assumed diesel import price increase (AUD/liter):Q",
-                            format=".1f",
-                        ),
-                        alt.Tooltip(
-                            "Ammonia import price increase (AUD/t NH3):Q",
-                            format=",.0f",
-                        ),
-                        alt.Tooltip(
-                            "System cost (MAUD/year):Q",
-                            format=",.2f",
-                        ),
-                        alt.Tooltip(
-                            "Additional system cost relative to baseline (MAUD/year):Q",
-                            format=",.2f",
-                        ),
-                        alt.Tooltip(
-                            "Value of displaced import exposure (MAUD/year):Q",
-                            format=",.2f",
-                        ),
-                        alt.Tooltip(
+                        y=alt.Y(
                             "Net insurance benefit (MAUD/year):Q",
-                            format=",.2f",
+                            title="Net insurance benefit (MAUD/year)",
+                            axis=alt.Axis(labelFontSize=18, titleFontSize=20),
                         ),
-                    ],
+                        color=alt.Color(
+                            "Scenario:N",
+                            title="Local e-fuel production share",
+                            scale=alt.Scale(
+                                domain=["0%", "20%", "40%", "60%", "80%", "100%"],
+                            ),
+                            legend=alt.Legend(
+                                orient="bottom",
+                                direction="horizontal",
+                                columns=6,
+                                labelFontSize=18,
+                                titleFontSize=20,
+                                labelLimit=0,
+                                titleLimit=0,
+                            ),
+                        ),
+                        tooltip=[
+                            "Scenario:N",
+                            alt.Tooltip(f"{x_col}:Q", format=",.2f"),
+                            alt.Tooltip("System cost (MAUD/year):Q", format=",.2f"),
+                            alt.Tooltip(
+                                "Additional system cost relative to baseline (MAUD/year):Q",
+                                format=",.2f",
+                            ),
+                            alt.Tooltip(
+                                "Value of displaced import exposure (MAUD/year):Q",
+                                format=",.2f",
+                            ),
+                            alt.Tooltip(
+                                "Net insurance benefit (MAUD/year):Q",
+                                format=",.2f",
+                            ),
+                        ],
+                    )
+                    .properties(height=650)
                 )
-                .properties(height=750)
+
+            st.subheader("Diesel import shock insurance")
+            st.altair_chart(
+                make_insurance_chart(
+                    diesel_df,
+                    "Assumed diesel import price increase (AUD/liter)",
+                    "Assumed diesel import price increase (AUD/liter)",
+                ),
+                width="stretch",
             )
 
-            st.altair_chart(chart, width="stretch")
+            st.subheader("Ammonia import shock insurance")
+            st.altair_chart(
+                make_insurance_chart(
+                    ammonia_df,
+                    "Assumed ammonia import price increase (AUD/t NH3)",
+                    "Assumed ammonia import price increase (AUD/t NH3)",
+                ),
+                width="stretch",
+            )
 
             st.info("""
-                **How to read this chart**
+                **How to interpret these charts**
 
-                - Each line represents a different level of **local e-fuel production** (0-100%). The same share is applied to both e-methanol production for diesel replacement and e-ammonia production for fertilizer demand.
-                - The **x-axis** shows hypothetical increases in imported diesel prices (AUD/liter).
-                - The **y-axis** shows the **net insurance benefit** (MAUD/year).
+                The charts estimate the **insurance value of domestic e-fuel production** against import price shocks.
 
-                Negative values mean the additional cost of domestic e-fuel production is larger than the value of reduced import exposure.
+                * Each line represents a different level of **local e-fuel production** (0–100%). The same share is applied to both **e-methanol** production for diesel replacement and **e-ammonia** production for fertilizer demand.
+                * The first chart shows the insurance value against **imported diesel price shocks**.
+                * The second chart shows the insurance value against **imported ammonia price shocks**.
+                * The **y-axis** shows the **net insurance benefit** (MAUD/year), calculated as the estimated value of reduced import exposure minus the additional annual system cost relative to the **0% local e-fuel production reference case**.
 
-                Positive values mean the value of reduced exposure to import price shocks exceeds the additional system cost.
+                At **zero import price shock**, the net insurance benefit is negative and equal to the additional annual system cost associated with domestic e-fuel production. As import prices increase, the value of reducing import exposure increases and the net insurance benefit improves.
 
-                The point where a line crosses **0 MAUD/year** indicates the diesel import price increase at which that local production level becomes economically justified from an insurance perspective.
+                The additional annual system cost is calculated as the difference in **PyPSA-AUS objective value** between each scenario and the **0% local e-fuel production reference case**.
 
-                This analysis does not explicitly model imports. It estimates the value of reducing exposure to future import price increases using precomputed PyPSA scenarios.
+                The point where a line crosses **0 MAUD/year** indicates the import price increase at which that level of local e-fuel production breaks even from an insurance perspective.
+
+                This analysis does not explicitly model imports. Instead, it estimates the value of reducing exposure to future import price increases using pre-computed PyPSA-AUS scenarios.
+
                 """)
 
-            with st.expander("Show scenario demand details", expanded=False):
+            scenario_detail_df = scenario_detail_df[
+                [
+                    "Scenario",
+                    "Additional system cost relative to baseline (MAUD/year)",
+                    "Additional diesel-equivalent fuel displacement relative to baseline (Mtpa)",
+                    "Additional e-ammonia relative to baseline (Mtpa)",
+                ]
+            ]
+
+            scenario_detail_df = scenario_detail_df.rename(
+                columns={
+                    "Additional system cost relative to baseline (MAUD/year)": (
+                        "Additional system cost (MAUD/year)"
+                    ),
+                    "Additional diesel-equivalent fuel displacement relative to baseline (Mtpa)": (
+                        "Additional diesel-equivalent fuel displacement (Mtpa)"
+                    ),
+                    "Additional e-ammonia relative to baseline (Mtpa)": (
+                        "Additional e-ammonia production (Mtpa)"
+                    ),
+                }
+            )
+
+            with st.expander(
+                "Show underlying assumptions for each production scenario",
+                expanded=False,
+            ):
                 st.dataframe(
                     scenario_detail_df.round(2),
                     hide_index=True,
@@ -2736,6 +2780,10 @@ with t_results:
         # ECONOMIC COMPARISON
 
         if result_view == "Economic comparison":
+            if st.session_state.results is None:
+                st.info("Run an optimization first to show the economic comparison.")
+                st.stop()
+
             df = st.session_state.results
             df = df.rename(columns=label_map)
             df = df / 1e3

--- a/streamlit/app.py
+++ b/streamlit/app.py
@@ -1790,21 +1790,18 @@ with t_results:
                 This analysis uses precomputed optimization results downloaded from Zenodo.
 
                 It is independent from any optimization runs performed in this application and
-                does not use the default Economic Parameters, Demand Parameters or Optimization
-                settings.
+                does not use the Economic Parameters, Demand Parameters or Optimization settings configured in this session.
 
                 The loaded network is only used to identify the network resolution
                 (10, 15 or 20 nodes) and select the corresponding precomputed scenarios.
                 """)
             st.markdown(f"""
-                **Dataset source:** [Zenodo record {INSURANCE_SCENARIO_RECORD_ID}]({INSURANCE_SCENARIO_URL})
-
                 Scenarios included:
-                - 20% local green production
-                - 40% local green production
-                - 60% local green production
-                - 80% local green production
-                - 100% local green production
+                - 20% green local production
+                - 40% green local production
+                - 60% green local production
+                - 80% green local production
+                - 100% green local production
                 """)
             if st.session_state.n is None:
                 st.info(
@@ -1825,9 +1822,6 @@ with t_results:
             st.markdown(f"""
                 Precomputed insurance scenarios for **{nodes} nodes** are downloaded from
                 [Zenodo]({INSURANCE_SCENARIO_URL}).
-
-                The analysis compares green local production shares of
-                20%, 40%, 60%, 80% and 100%.
                 """)
 
             try:
@@ -1838,23 +1832,38 @@ with t_results:
                 st.error(f"Could not load precomputed insurance scenarios: {exc}")
                 st.stop()
 
+            scenario_display_labels = {
+                key: f"{key.replace('greenlocprod', '')}% local green production"
+                for key in insurance_networks
+            }
+
             baseline_label = st.selectbox(
                 "Select baseline scenario",
                 list(insurance_networks.keys()),
                 index=0,
+                format_func=lambda key: scenario_display_labels[key],
             )
 
             diesel_shocks = st.multiselect(
-                "Diesel-equivalent import price increase (AUD/t)",
+                "Assumed increase in imported fuel prices (AUD/t diesel-equivalent)",
                 [0, 150, 300, 450, 600],
                 default=[0, 150, 300, 450, 600],
             )
 
+            st.caption(
+                "These are post-processing sensitivity assumptions representing potential increases in imported fuel prices. "
+                "They are not optimized in the model."
+            )
+
             ammonia_shock = st.number_input(
-                "Ammonia import price increase (AUD/t NH3)",
+                "Assumed ammonia import price shock (AUD/t NH3)",
                 min_value=0.0,
                 value=0.0,
                 step=50.0,
+            )
+
+            st.caption(
+                "This shock is applied to additional e-ammonia production relative to the selected baseline."
             )
 
             baseline_network = insurance_networks[baseline_label]
@@ -1869,6 +1878,7 @@ with t_results:
             )
 
             rows = []
+            scenario_detail_rows = []
 
             for scenario_label, scenario_network in insurance_networks.items():
                 scenario_cost = scenario_network.objective / 1e6
@@ -1883,34 +1893,78 @@ with t_results:
                 )
 
                 additional_system_cost = scenario_cost - baseline_cost
-                additional_meoh = max(e_meoh - baseline_meoh, 0.0)
+                additional_green_fuel = max(e_meoh - baseline_meoh, 0.0)
+                additional_diesel_equivalent = (
+                    additional_green_fuel
+                    * MWH_PER_TONNE["e_methanol"]
+                    / MWH_PER_TONNE["diesel"]
+                )
                 additional_nh3 = max(e_nh3 - baseline_nh3, 0.0)
 
+                scenario_detail_rows.append(
+                    {
+                        "Scenario": scenario_display_labels[scenario_label],
+                        "System cost (MAUD/year)": scenario_cost,
+                        "Additional system cost relative to baseline (MAUD/year)": additional_system_cost,
+                        "e-methanol production for diesel replacement (Mtpa)": e_meoh,
+                        "e-ammonia production (Mtpa)": e_nh3,
+                        "Additional e-methanol relative to baseline (Mtpa)": additional_green_fuel,
+                        "Additional diesel-equivalent fuel displacement relative to baseline (Mtpa)": additional_diesel_equivalent,
+                        "Additional e-ammonia relative to baseline (Mtpa)": additional_nh3,
+                    }
+                )
+
                 for diesel_shock in diesel_shocks:
-                    avoided_import_expenditure = (
-                        additional_meoh * 1e6 * diesel_shock
+                    value_of_displaced_import_exposure = (
+                        additional_diesel_equivalent * 1e6 * diesel_shock
                         + additional_nh3 * 1e6 * ammonia_shock
                     ) / 1e6
 
-                    insurance_value = (
-                        avoided_import_expenditure - additional_system_cost
+                    net_insurance_benefit = (
+                        value_of_displaced_import_exposure - additional_system_cost
                     )
 
                     rows.append(
                         {
-                            "Scenario": scenario_label,
-                            "Diesel-equivalent shock (AUD/t)": diesel_shock,
-                            "Ammonia shock (AUD/t NH3)": ammonia_shock,
+                            "Scenario": scenario_display_labels[scenario_label],
+                            "Assumed diesel-equivalent import price increase (AUD/t)": diesel_shock,
+                            "Ammonia import price increase (AUD/t NH3)": ammonia_shock,
                             "System cost (MAUD/year)": scenario_cost,
-                            "Additional system cost (MAUD/year)": additional_system_cost,
-                            "Avoided import expenditure (MAUD/year)": avoided_import_expenditure,
-                            "Insurance value (MAUD/year)": insurance_value,
-                            "e-methanol demand (Mtpa)": e_meoh,
-                            "e-ammonia demand (Mtpa)": e_nh3,
+                            "Additional system cost relative to baseline (MAUD/year)": additional_system_cost,
+                            "Value of displaced import exposure (MAUD/year)": value_of_displaced_import_exposure,
+                            "Net insurance benefit (MAUD/year)": net_insurance_benefit,
                         }
                     )
 
             insurance_df = pd.DataFrame(rows)
+            scenario_detail_df = pd.DataFrame(scenario_detail_rows)
+
+            st.info("""
+                The chart shows the net insurance benefit for each local green
+                production scenario and each assumed import price shock.
+
+                For each scenario and shock level:
+
+                Net insurance benefit =
+                Value of displaced import exposure
+                - Additional system cost relative to the selected baseline.
+
+                Value of displaced import exposure =
+                Additional diesel-equivalent fuel displacement × assumed fuel price shock
+                + additional e-ammonia production × assumed ammonia price shock.
+
+                Additional diesel-equivalent fuel displacement is calculated from
+                additional e-methanol production using the energy-content ratio:
+
+                Additional diesel-equivalent fuel displacement =
+                Additional e-methanol production
+                × MWh per tonne e-methanol
+                / MWh per tonne diesel.
+
+                The analysis does not model imports explicitly. Instead, it estimates
+                the economic value of reducing exposure to imported liquid fuels and
+                ammonia under assumed import price increases.
+                """)
 
             st.dataframe(
                 insurance_df.round(2),
@@ -1918,34 +1972,50 @@ with t_results:
                 width="stretch",
             )
 
+            with st.expander("Show scenario demand details", expanded=False):
+                st.dataframe(
+                    scenario_detail_df.round(2),
+                    hide_index=True,
+                    width="stretch",
+                )
+
             chart = (
                 alt.Chart(insurance_df)
                 .mark_line(point=True)
                 .encode(
                     x=alt.X(
-                        "Diesel-equivalent shock (AUD/t):Q",
-                        title="Diesel-equivalent import price increase (AUD/t)",
+                        "Assumed diesel-equivalent import price increase (AUD/t):Q",
+                        title="Assumed diesel-equivalent import price increase (AUD/t)",
                     ),
                     y=alt.Y(
-                        "Insurance value (MAUD/year):Q",
-                        title="Insurance value (MAUD/year)",
+                        "Net insurance benefit (MAUD/year):Q",
+                        title="Net insurance benefit (MAUD/year)",
                     ),
                     color=alt.Color("Scenario:N", title="Scenario"),
                     tooltip=[
                         "Scenario:N",
-                        alt.Tooltip("Diesel-equivalent shock (AUD/t):Q"),
-                        alt.Tooltip("Ammonia shock (AUD/t NH3):Q"),
-                        alt.Tooltip("System cost (MAUD/year):Q", format=",.2f"),
                         alt.Tooltip(
-                            "Additional system cost (MAUD/year):Q",
+                            "Assumed diesel-equivalent import price increase (AUD/t):Q",
+                            format=",.0f",
+                        ),
+                        alt.Tooltip(
+                            "Ammonia import price increase (AUD/t NH3):Q",
+                            format=",.0f",
+                        ),
+                        alt.Tooltip(
+                            "System cost (MAUD/year):Q",
                             format=",.2f",
                         ),
                         alt.Tooltip(
-                            "Avoided import expenditure (MAUD/year):Q",
+                            "Additional system cost relative to baseline (MAUD/year):Q",
                             format=",.2f",
                         ),
                         alt.Tooltip(
-                            "Insurance value (MAUD/year):Q",
+                            "Value of displaced import exposure (MAUD/year):Q",
+                            format=",.2f",
+                        ),
+                        alt.Tooltip(
+                            "Net insurance benefit (MAUD/year):Q",
                             format=",.2f",
                         ),
                     ],

--- a/streamlit/app.py
+++ b/streamlit/app.py
@@ -779,8 +779,9 @@ tabs = [
     "| 2. 📊 Demands",
     "| 3. ⚡ Optimization",
     "| 4. 📈 Results",
+    "| 5. 🛡️ Import shock insurance ",
 ]
-t_welcome, t_economic, t_demand, t_optimization, t_results = st.tabs(tabs)
+t_welcome, t_economic, t_demand, t_optimization, t_results, t_insurance = st.tabs(tabs)
 
 # TAB WELCOME
 with t_welcome:
@@ -1780,294 +1781,9 @@ with t_results:
                 "System costs",
                 # "Technical comparison",
                 "Economic comparison",
-                "Import shock insurance",
             ],
             horizontal=True,
         )
-
-        if result_view == "Import shock insurance":
-            st.info("""
-                This analysis uses precomputed optimization results downloaded from Zenodo.
-
-                It is independent from any optimization runs performed in this application and
-                does not use the Economic Parameters, Demand Parameters or Optimization settings configured in this session.
-
-                The loaded network is only used to identify the network resolution
-                (10, 15 or 20 nodes) and select the corresponding precomputed scenarios.
-                """)
-            st.markdown(f"""
-                Scenarios included:
-                - 0% local e-fuel production
-                - 20% local e-fuel production
-                - 40% local e-fuel production
-                - 60% local e-fuel production
-                - 80% local e-fuel production
-                - 100% local e-fuel production
-                """)
-            if st.session_state.n is None:
-                st.info(
-                    "Please load a base network first. The loaded network is used "
-                    "to infer whether the 10, 15 or 20 node insurance scenarios "
-                    "should be downloaded."
-                )
-                st.stop()
-
-            raw_nodes = infer_network_clusters(st.session_state.n)
-
-            nodes = {
-                9: 10,
-                14: 15,
-                19: 20,
-            }.get(raw_nodes, raw_nodes)
-
-            st.markdown(f"""
-                Precomputed insurance scenarios for **{nodes} nodes** are downloaded from
-                [Zenodo]({INSURANCE_SCENARIO_URL}).
-                """)
-
-            try:
-                with st.spinner("Downloading precomputed insurance scenarios..."):
-                    insurance_networks = load_precomputed_insurance_scenarios(nodes)
-
-            except Exception as exc:
-                st.error(f"Could not load precomputed insurance scenarios: {exc}")
-                st.stop()
-
-            scenario_display_labels = {
-                key: f"{key.replace('greenlocprod', '')}%" for key in insurance_networks
-            }
-
-            baseline_label = "greenlocprod0"
-
-            st.info(
-                "All scenarios are compared against the 0% local e-fuel production reference case."
-            )
-
-            diesel_shocks_l = [0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
-            ammonia_shocks = [
-                0,
-                300,
-                600,
-                900,
-                1200,
-                1500,
-                1800,
-                2100,
-                2400,
-                2700,
-                3000,
-            ]
-
-            baseline_network = insurance_networks[baseline_label]
-            baseline_cost = baseline_network.objective / 1e6
-            baseline_meoh = get_network_demand_mtpa(baseline_network, "e_methanol")
-            baseline_nh3 = get_network_demand_mtpa(baseline_network, "e_ammonia")
-
-            diesel_rows = []
-            ammonia_rows = []
-            scenario_detail_rows = []
-
-            for scenario_label, scenario_network in insurance_networks.items():
-                scenario_cost = scenario_network.objective / 1e6
-
-                e_meoh = get_network_demand_mtpa(scenario_network, "e_methanol")
-                e_nh3 = get_network_demand_mtpa(scenario_network, "e_ammonia")
-
-                additional_system_cost = scenario_cost - baseline_cost
-                additional_green_fuel = max(e_meoh - baseline_meoh, 0.0)
-                additional_diesel_equivalent = (
-                    additional_green_fuel
-                    * MWH_PER_TONNE["e_methanol"]
-                    / MWH_PER_TONNE["diesel"]
-                )
-                additional_nh3 = max(e_nh3 - baseline_nh3, 0.0)
-
-                scenario_detail_rows.append(
-                    {
-                        "Scenario": scenario_display_labels[scenario_label],
-                        "System cost (MAUD/year)": scenario_cost,
-                        "Additional system cost relative to baseline (MAUD/year)": additional_system_cost,
-                        "e-methanol production for diesel replacement (Mtpa)": e_meoh,
-                        "e-ammonia production (Mtpa)": e_nh3,
-                        "Additional e-methanol relative to baseline (Mtpa)": additional_green_fuel,
-                        "Additional diesel-equivalent fuel displacement relative to baseline (Mtpa)": additional_diesel_equivalent,
-                        "Additional e-ammonia relative to baseline (Mtpa)": additional_nh3,
-                    }
-                )
-
-                for diesel_shock_l in diesel_shocks_l:
-                    diesel_shock = diesel_shock_l * 1000 / KG_PER_LITER_DIESEL
-
-                    value_of_displaced_import_exposure = (
-                        additional_diesel_equivalent * 1e6 * diesel_shock
-                    ) / 1e6
-
-                    net_insurance_benefit = (
-                        value_of_displaced_import_exposure - additional_system_cost
-                    )
-
-                    diesel_rows.append(
-                        {
-                            "Scenario": scenario_display_labels[scenario_label],
-                            "Assumed diesel import price increase (AUD/liter)": diesel_shock_l,
-                            "System cost (MAUD/year)": scenario_cost,
-                            "Additional system cost relative to baseline (MAUD/year)": additional_system_cost,
-                            "Value of displaced import exposure (MAUD/year)": value_of_displaced_import_exposure,
-                            "Net insurance benefit (MAUD/year)": net_insurance_benefit,
-                        }
-                    )
-
-                for ammonia_shock in ammonia_shocks:
-                    value_of_displaced_import_exposure = (
-                        additional_nh3 * 1e6 * ammonia_shock
-                    ) / 1e6
-
-                    net_insurance_benefit = (
-                        value_of_displaced_import_exposure - additional_system_cost
-                    )
-
-                    ammonia_rows.append(
-                        {
-                            "Scenario": scenario_display_labels[scenario_label],
-                            "Assumed ammonia import price increase (AUD/t NH3)": ammonia_shock,
-                            "System cost (MAUD/year)": scenario_cost,
-                            "Additional system cost relative to baseline (MAUD/year)": additional_system_cost,
-                            "Value of displaced import exposure (MAUD/year)": value_of_displaced_import_exposure,
-                            "Net insurance benefit (MAUD/year)": net_insurance_benefit,
-                        }
-                    )
-
-            diesel_df = pd.DataFrame(diesel_rows)
-            ammonia_df = pd.DataFrame(ammonia_rows)
-            scenario_detail_df = pd.DataFrame(scenario_detail_rows)
-
-            def make_insurance_chart(df, x_col, x_title):
-                return (
-                    alt.Chart(df)
-                    .mark_line(point=True, strokeWidth=3, size=80)
-                    .encode(
-                        x=alt.X(
-                            f"{x_col}:Q",
-                            title=x_title,
-                            axis=alt.Axis(labelFontSize=18, titleFontSize=20),
-                        ),
-                        y=alt.Y(
-                            "Net insurance benefit (MAUD/year):Q",
-                            title="Net insurance benefit (MAUD/year)",
-                            axis=alt.Axis(labelFontSize=18, titleFontSize=20),
-                        ),
-                        color=alt.Color(
-                            "Scenario:N",
-                            title="Local e-fuel production share",
-                            scale=alt.Scale(
-                                domain=["0%", "20%", "40%", "60%", "80%", "100%"],
-                            ),
-                            legend=alt.Legend(
-                                orient="bottom",
-                                direction="horizontal",
-                                columns=6,
-                                labelFontSize=18,
-                                titleFontSize=20,
-                                labelLimit=0,
-                                titleLimit=0,
-                            ),
-                        ),
-                        tooltip=[
-                            "Scenario:N",
-                            alt.Tooltip(f"{x_col}:Q", format=",.2f"),
-                            alt.Tooltip("System cost (MAUD/year):Q", format=",.2f"),
-                            alt.Tooltip(
-                                "Additional system cost relative to baseline (MAUD/year):Q",
-                                format=",.2f",
-                            ),
-                            alt.Tooltip(
-                                "Value of displaced import exposure (MAUD/year):Q",
-                                format=",.2f",
-                            ),
-                            alt.Tooltip(
-                                "Net insurance benefit (MAUD/year):Q",
-                                format=",.2f",
-                            ),
-                        ],
-                    )
-                    .properties(height=650)
-                )
-
-            st.subheader("Diesel import shock insurance")
-            st.altair_chart(
-                make_insurance_chart(
-                    diesel_df,
-                    "Assumed diesel import price increase (AUD/liter)",
-                    "Assumed diesel import price increase (AUD/liter)",
-                ),
-                width="stretch",
-            )
-
-            st.subheader("Ammonia import shock insurance")
-            st.altair_chart(
-                make_insurance_chart(
-                    ammonia_df,
-                    "Assumed ammonia import price increase (AUD/t NH3)",
-                    "Assumed ammonia import price increase (AUD/t NH3)",
-                ),
-                width="stretch",
-            )
-
-            st.info("""
-                **How to interpret these charts**
-
-                The charts estimate the **insurance value of domestic e-fuel production** against import price shocks.
-
-                * Each line represents a different level of **local e-fuel production** (0–100%). The same share is applied to both **e-methanol** production for diesel replacement and **e-ammonia** production for fertilizer demand.
-                * The first chart shows the insurance value against **imported diesel price shocks**.
-                * The second chart shows the insurance value against **imported ammonia price shocks**.
-                * The **y-axis** shows the **net insurance benefit** (MAUD/year), calculated as the estimated value of reduced import exposure minus the additional annual system cost relative to the **0% local e-fuel production reference case**.
-
-                At **zero import price shock**, the net insurance benefit is negative and equal to the additional annual system cost associated with domestic e-fuel production. As import prices increase, the value of reducing import exposure increases and the net insurance benefit improves.
-
-                The additional annual system cost is calculated as the difference in **PyPSA-AUS objective value** between each scenario and the **0% local e-fuel production reference case**.
-
-                The point where a line crosses **0 MAUD/year** indicates the import price increase at which that level of local e-fuel production breaks even from an insurance perspective.
-
-                This analysis does not explicitly model imports. Instead, it estimates the value of reducing exposure to future import price increases using pre-computed PyPSA-AUS scenarios.
-
-                """)
-
-            scenario_detail_df = scenario_detail_df[
-                [
-                    "Scenario",
-                    "Additional system cost relative to baseline (MAUD/year)",
-                    "Additional diesel-equivalent fuel displacement relative to baseline (Mtpa)",
-                    "Additional e-ammonia relative to baseline (Mtpa)",
-                ]
-            ]
-
-            scenario_detail_df = scenario_detail_df.rename(
-                columns={
-                    "Scenario": "Local e-fuel production share",
-                    "Additional system cost relative to baseline (MAUD/year)": (
-                        "Annual insurance cost (MAUD/year)"
-                    ),
-                    "Additional diesel-equivalent fuel displacement relative to baseline (Mtpa)": (
-                        "Reduced diesel import exposure (Mtpa diesel-eq.)"
-                    ),
-                    "Additional e-ammonia relative to baseline (Mtpa)": (
-                        "Reduced ammonia import exposure (Mtpa NH3)"
-                    ),
-                }
-            )
-
-            with st.expander(
-                "Show underlying assumptions for each production scenario",
-                expanded=False,
-            ):
-                st.dataframe(
-                    scenario_detail_df.round(2),
-                    hide_index=True,
-                    width="stretch",
-                )
-
-            st.stop()
 
         if selected_runs:
             selected_networks = {
@@ -2808,3 +2524,272 @@ with t_results:
         st.write("""
             After running an optimization, you will see a detailed breakdown of the expanded capacities and economic outcomes for each technology, allowing you to assess the impact of your parameter adjustments on the network's performance and costs.
             """)
+
+# TAB IMPORT SHOCK INSURANCE
+with t_insurance:
+    st.header("Import Shock Insurance")
+    st.info("""
+    This analysis uses precomputed optimization results downloaded from Zenodo.
+
+    It is completely independent from any optimization runs performed in this application and does not use the Economic Parameters, Demand Parameters or Optimization settings configured in this session.
+
+    The analysis is based on a fixed set of precomputed **20-node PyPSA-AUS scenarios**, ranging from 0% to 100% local e-fuel production.
+    """)
+    st.markdown(f"""
+        Scenarios included:
+        - 0% local e-fuel production
+        - 20% local e-fuel production
+        - 40% local e-fuel production
+        - 60% local e-fuel production
+        - 80% local e-fuel production
+        - 100% local e-fuel production
+        """)
+
+    nodes = 20
+
+    st.markdown(f"""
+        Precomputed insurance scenarios for **{nodes} nodes** are downloaded from
+        [Zenodo]({INSURANCE_SCENARIO_URL}).
+    """)
+
+    try:
+        with st.spinner("Downloading precomputed insurance scenarios..."):
+            insurance_networks = load_precomputed_insurance_scenarios(nodes)
+
+    except Exception as exc:
+        st.error(f"Could not load precomputed insurance scenarios: {exc}")
+        st.stop()
+
+    scenario_display_labels = {
+        key: f"{key.replace('greenlocprod', '')}%" for key in insurance_networks
+    }
+
+    baseline_label = "greenlocprod0"
+
+    st.info(
+        "All scenarios are compared against the 0% local e-fuel production reference case."
+    )
+
+    diesel_shocks_l = [0.0, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
+    ammonia_shocks = [
+        0,
+        300,
+        600,
+        900,
+        1200,
+        1500,
+        1800,
+        2100,
+        2400,
+        2700,
+        3000,
+    ]
+
+    baseline_network = insurance_networks[baseline_label]
+    baseline_cost = baseline_network.objective / 1e6
+    baseline_meoh = get_network_demand_mtpa(baseline_network, "e_methanol")
+    baseline_nh3 = get_network_demand_mtpa(baseline_network, "e_ammonia")
+
+    diesel_rows = []
+    ammonia_rows = []
+    scenario_detail_rows = []
+
+    for scenario_label, scenario_network in insurance_networks.items():
+        scenario_cost = scenario_network.objective / 1e6
+
+        e_meoh = get_network_demand_mtpa(scenario_network, "e_methanol")
+        e_nh3 = get_network_demand_mtpa(scenario_network, "e_ammonia")
+
+        additional_system_cost = scenario_cost - baseline_cost
+        additional_green_fuel = max(e_meoh - baseline_meoh, 0.0)
+        additional_diesel_equivalent = (
+            additional_green_fuel
+            * MWH_PER_TONNE["e_methanol"]
+            / MWH_PER_TONNE["diesel"]
+        )
+        additional_nh3 = max(e_nh3 - baseline_nh3, 0.0)
+
+        scenario_detail_rows.append(
+            {
+                "Scenario": scenario_display_labels[scenario_label],
+                "System cost (MAUD/year)": scenario_cost,
+                "Additional system cost relative to baseline (MAUD/year)": additional_system_cost,
+                "e-methanol production for diesel replacement (Mtpa)": e_meoh,
+                "e-ammonia production (Mtpa)": e_nh3,
+                "Additional e-methanol relative to baseline (Mtpa)": additional_green_fuel,
+                "Additional diesel-equivalent fuel displacement relative to baseline (Mtpa)": additional_diesel_equivalent,
+                "Additional e-ammonia relative to baseline (Mtpa)": additional_nh3,
+            }
+        )
+
+        for diesel_shock_l in diesel_shocks_l:
+            diesel_shock = diesel_shock_l * 1000 / KG_PER_LITER_DIESEL
+
+            value_of_displaced_import_exposure = (
+                additional_diesel_equivalent * 1e6 * diesel_shock
+            ) / 1e6
+
+            net_insurance_benefit = (
+                value_of_displaced_import_exposure - additional_system_cost
+            )
+
+            diesel_rows.append(
+                {
+                    "Scenario": scenario_display_labels[scenario_label],
+                    "Assumed diesel import price increase (AUD/liter)": diesel_shock_l,
+                    "System cost (MAUD/year)": scenario_cost,
+                    "Additional system cost relative to baseline (MAUD/year)": additional_system_cost,
+                    "Value of displaced import exposure (MAUD/year)": value_of_displaced_import_exposure,
+                    "Net insurance benefit (MAUD/year)": net_insurance_benefit,
+                }
+            )
+
+        for ammonia_shock in ammonia_shocks:
+            value_of_displaced_import_exposure = (
+                additional_nh3 * 1e6 * ammonia_shock
+            ) / 1e6
+
+            net_insurance_benefit = (
+                value_of_displaced_import_exposure - additional_system_cost
+            )
+
+            ammonia_rows.append(
+                {
+                    "Scenario": scenario_display_labels[scenario_label],
+                    "Assumed ammonia import price increase (AUD/t NH3)": ammonia_shock,
+                    "System cost (MAUD/year)": scenario_cost,
+                    "Additional system cost relative to baseline (MAUD/year)": additional_system_cost,
+                    "Value of displaced import exposure (MAUD/year)": value_of_displaced_import_exposure,
+                    "Net insurance benefit (MAUD/year)": net_insurance_benefit,
+                }
+            )
+
+    diesel_df = pd.DataFrame(diesel_rows)
+    ammonia_df = pd.DataFrame(ammonia_rows)
+    scenario_detail_df = pd.DataFrame(scenario_detail_rows)
+
+    def make_insurance_chart(df, x_col, x_title):
+        return (
+            alt.Chart(df)
+            .mark_line(point=True, strokeWidth=3, size=80)
+            .encode(
+                x=alt.X(
+                    f"{x_col}:Q",
+                    title=x_title,
+                    axis=alt.Axis(labelFontSize=18, titleFontSize=20),
+                ),
+                y=alt.Y(
+                    "Net insurance benefit (MAUD/year):Q",
+                    title="Net insurance benefit (MAUD/year)",
+                    axis=alt.Axis(labelFontSize=18, titleFontSize=20),
+                ),
+                color=alt.Color(
+                    "Scenario:N",
+                    title="Local e-fuel production share",
+                    scale=alt.Scale(
+                        domain=["0%", "20%", "40%", "60%", "80%", "100%"],
+                    ),
+                    legend=alt.Legend(
+                        orient="bottom",
+                        direction="horizontal",
+                        columns=6,
+                        labelFontSize=18,
+                        titleFontSize=20,
+                        labelLimit=0,
+                        titleLimit=0,
+                    ),
+                ),
+                tooltip=[
+                    "Scenario:N",
+                    alt.Tooltip(f"{x_col}:Q", format=",.2f"),
+                    alt.Tooltip("System cost (MAUD/year):Q", format=",.2f"),
+                    alt.Tooltip(
+                        "Additional system cost relative to baseline (MAUD/year):Q",
+                        format=",.2f",
+                    ),
+                    alt.Tooltip(
+                        "Value of displaced import exposure (MAUD/year):Q",
+                        format=",.2f",
+                    ),
+                    alt.Tooltip(
+                        "Net insurance benefit (MAUD/year):Q",
+                        format=",.2f",
+                    ),
+                ],
+            )
+            .properties(height=650)
+        )
+
+    st.subheader("Diesel import shock insurance")
+    st.altair_chart(
+        make_insurance_chart(
+            diesel_df,
+            "Assumed diesel import price increase (AUD/liter)",
+            "Assumed diesel import price increase (AUD/liter)",
+        ),
+        width="stretch",
+    )
+
+    st.subheader("Ammonia import shock insurance")
+    st.altair_chart(
+        make_insurance_chart(
+            ammonia_df,
+            "Assumed ammonia import price increase (AUD/t NH3)",
+            "Assumed ammonia import price increase (AUD/t NH3)",
+        ),
+        width="stretch",
+    )
+
+    st.info("""
+        **How to interpret these charts**
+
+        The charts estimate the **insurance value of domestic e-fuel production** against import price shocks.
+
+        * Each line represents a different level of **local e-fuel production** (0–100%). The same share is applied to both **e-methanol** production for diesel replacement and **e-ammonia** production for fertilizer demand.
+        * The first chart shows the insurance value against **imported diesel price shocks**.
+        * The second chart shows the insurance value against **imported ammonia price shocks**.
+        * The **y-axis** shows the **net insurance benefit** (MAUD/year), calculated as the estimated value of reduced import exposure minus the additional annual system cost relative to the **0% local e-fuel production reference case**.
+
+        At **zero import price shock**, the net insurance benefit is negative and equal to the additional annual system cost associated with domestic e-fuel production. As import prices increase, the value of reducing import exposure increases and the net insurance benefit improves.
+
+        The additional annual system cost is calculated as the difference in **PyPSA-AUS objective value** between each scenario and the **0% local e-fuel production reference case**.
+
+        The point where a line crosses **0 MAUD/year** indicates the import price increase at which that level of local e-fuel production breaks even from an insurance perspective.
+
+        This analysis does not explicitly model imports. Instead, it estimates the value of reducing exposure to future import price increases using pre-computed PyPSA-AUS scenarios.
+
+        """)
+
+    scenario_detail_df = scenario_detail_df[
+        [
+            "Scenario",
+            "Additional system cost relative to baseline (MAUD/year)",
+            "Additional diesel-equivalent fuel displacement relative to baseline (Mtpa)",
+            "Additional e-ammonia relative to baseline (Mtpa)",
+        ]
+    ]
+
+    scenario_detail_df = scenario_detail_df.rename(
+        columns={
+            "Scenario": "Local e-fuel production share",
+            "Additional system cost relative to baseline (MAUD/year)": (
+                "Annual insurance cost (MAUD/year)"
+            ),
+            "Additional diesel-equivalent fuel displacement relative to baseline (Mtpa)": (
+                "Reduced diesel import exposure (Mtpa diesel-eq.)"
+            ),
+            "Additional e-ammonia relative to baseline (Mtpa)": (
+                "Reduced ammonia import exposure (Mtpa NH3)"
+            ),
+        }
+    )
+
+    with st.expander(
+        "Show underlying assumptions for each production scenario",
+        expanded=False,
+    ):
+        st.dataframe(
+            scenario_detail_df.round(2),
+            hide_index=True,
+            width="stretch",
+        )


### PR DESCRIPTION
This PR adds a new **Import Shock Insurance** results view based on precomputed PyPSA-AUS scenarios hosted on Zenodo.

The feature:

* Automatically detects the loaded network resolution (10, 15 or 20 nodes)
* Downloads the corresponding precomputed scenario set from Zenodo
* Compares local e-fuel production shares of 0%, 20%, 40%, 60%, 80% and 100%
* Uses the 0% local e-fuel production scenario as the reference case
* Computes the additional annual system cost relative to the baseline from the PyPSA objective value
* Estimates the value of reduced import exposure for:

  * diesel imports via domestic e-methanol production
  * ammonia imports via domestic e-ammonia production
* Displays interactive insurance-value curves showing the net insurance benefit under a range of assumed diesel and ammonia import price shocks
* Provides a summary table with the additional system cost and reduced import exposure associated with each production scenario

The analysis is independent of optimization runs performed within the application. The loaded network is only used to identify the appropriate precomputed scenario set (10, 15 or 20 nodes).

The insurance value is calculated as:

Net insurance benefit = Value of reduced import exposure − Additional annual system cost

where the additional annual system cost is derived from the difference in PyPSA objective value between each scenario and the 0% local e-fuel production reference case.
